### PR TITLE
Replace force cast with safer conditional cast in SkieSwiftFlowIterator

### DIFF
--- a/SKIE/kotlin-compiler/core/src/commonMain/kotlin/co/touchlab/skie/phases/runtime/SkieSwiftFlowIteratorGenerator.kt
+++ b/SKIE/kotlin-compiler/core/src/commonMain/kotlin/co/touchlab/skie/phases/runtime/SkieSwiftFlowIteratorGenerator.kt
@@ -80,7 +80,11 @@ object SkieSwiftFlowIteratorGenerator {
                         |    let hasNext = try await skie(iterator).hasNext()
                         |
                         |    if hasNext.boolValue {
-                        |        return .some(iterator.next() as! Element)
+                        |        if let element = iterator.next() as? Element {
+                        |            return .some(element)
+                        |        } else {
+                        |            return nil
+                        |        }
                         |    } else {
                         |        return nil
                         |    }


### PR DESCRIPTION
We encountered a crash on iOS when consuming a Kotlin Flow<Set<String>> via SKIE as a Swift AsyncSequence. The error is:

`Could not cast value of type 'NSNull' to 'NSString'`

This occurs even though we only emit strings from Kotlin. The root cause is that the current SKIE Swift bridge uses a forced cast (as! Element), which crashes if any unexpected value (like NSNull) ends up in the flow due to deserialization quirks or race conditions.

This PR improves safety by replacing the forced cast with a conditional cast (as? Element).