### PR TITLE
Feature/kotlin 2.3.21 support

### DIFF
--- a/common-gradle/gradle.properties
+++ b/common-gradle/gradle.properties
@@ -25,7 +25,7 @@ versionSupport.kotlin.klibCompiler=2.0.21
 #versionSupport.kotlin.enabledVersions=2.2.20
 #versionSupport.kotlin.enabledVersions=2.3.0
 #versionSupport.kotlin.enabledVersions=2.3.20
-#versionSupport.kotlin.enabledVersions=2.3.20[2.3.21]
+#versionSupport.kotlin.enabledVersions=2.3.21
 
 #skie.kgpVersion=2.2.0
 

--- a/common-gradle/gradle.properties
+++ b/common-gradle/gradle.properties
@@ -15,7 +15,7 @@ kotlin.suppressGradlePluginWarnings=IncorrectCompileOnlyDependencyWarning
 
 pluginId=co.touchlab.skie
 
-versionSupport.kotlin=2.0.0(2.0.10), 2.0.20(2.0.21), 2.1.0(2.1.10), 2.1.20(2.1.21), 2.2.0(2.2.10), 2.2.20(2.2.21), 2.3.0(2.3.10), 2.3.20
+versionSupport.kotlin=2.0.0(2.0.10), 2.0.20(2.0.21), 2.1.0(2.1.10), 2.1.20(2.1.21), 2.2.0(2.2.10), 2.2.20(2.2.21), 2.3.0(2.3.10), 2.3.20(2.3.21)
 versionSupport.kotlin.klibCompiler=2.0.21
 #versionSupport.kotlin.enabledVersions=2.0.0
 #versionSupport.kotlin.enabledVersions=2.0.20
@@ -25,6 +25,7 @@ versionSupport.kotlin.klibCompiler=2.0.21
 #versionSupport.kotlin.enabledVersions=2.2.20
 #versionSupport.kotlin.enabledVersions=2.3.0
 #versionSupport.kotlin.enabledVersions=2.3.20
+#versionSupport.kotlin.enabledVersions=2.3.20[2.3.21]
 
 #skie.kgpVersion=2.2.0
 

--- a/dev-support/build.gradle.kts
+++ b/dev-support/build.gradle.kts
@@ -4,7 +4,8 @@ plugins {
 //     kotlin("multiplatform") version "2.2.20" apply false
 //     kotlin("multiplatform") version "2.2.21" apply false
 //     kotlin("multiplatform") version "2.3.0-RC" apply false
-    kotlin("multiplatform") version "2.3.20" apply false
+//     kotlin("multiplatform") version "2.3.20" apply false
+    kotlin("multiplatform") version "2.3.21" apply false
 }
 
 buildscript {


### PR DESCRIPTION
## Summary

Declares Kotlin 2.3.21 as a supported sub-compiler under the 2.3.20 baseline, following the same pattern used for previous patch versions (2.0.10, 2.0.21, 2.1.10, 2.1.21, 2.2.10, 2.2.21, 2.3.10).

## Notes

This was verified by building `:kotlin-compiler:kotlin-compiler-linker-plugin:compileKotlin` against 2.3.21 and tests for 2.3.20

Fixes (hopefully!) https://github.com/touchlab/SKIE/issues/184