### PR TITLE
Fix isolated-projects incompatibility from dynamic property lookup

### DIFF
--- a/SKIE/skie-gradle/plugin-impl/src/main/kotlin/co/touchlab/skie/plugin/shim/SkieKotlinVariantResolver.kt
+++ b/SKIE/skie-gradle/plugin-impl/src/main/kotlin/co/touchlab/skie/plugin/shim/SkieKotlinVariantResolver.kt
@@ -100,7 +100,7 @@ object SkieKotlinVariantResolver {
     }
 
     private fun Project.findKotlinGradlePluginVersionFromOverrideProperty(): String? =
-        (findProperty("skie.kgpVersion") as? String)?.also {
+        providers.gradleProperty("skie.kgpVersion").orNull?.also {
             logger.debug("[SKIE] Found KGP version override: $it in project '${project.path}', skipping resolution.")
         }
 


### PR DESCRIPTION
## Problem

With Gradle's Isolated Projects enabled
(`-Dorg.gradle.unsafe.isolated-projects=true`), applying the SKIE plugin
fails configuration with:

> Plugin 'co.touchlab.skie': Project ':app' cannot dynamically look up a
> property in the parent project ':'

The configuration-cache report points at
`SkieKotlinVariantResolver.findKotlinGradlePluginVersionFromOverrideProperty`
(line 103), which uses `Project.findProperty("skie.kgpVersion")`. That API
walks up to the parent project's properties, which Isolated Projects
forbids because it couples configuration of the subproject to the root.

## Fix

Replace `findProperty(...) as? String` with
`providers.gradleProperty(...).orNull`. The new API:

- Reads the same surface: `gradle.properties` at root and subproject, plus
  `-P` CLI properties — so users who set `skie.kgpVersion` anywhere still
  have it picked up.
- Returns a `Provider<String>` resolved through Gradle's lazy
  value-supplier model, which is the documented Isolated Projects-safe
  replacement for dynamic `findProperty` calls.

The fixed private helper is the only path to `skie.kgpVersion`, so this
one-line change covers both call sites that need the override (warning
emission and the actual version lookup).

## Reproduction

In any KMP project with SKIE applied:

./gradlew help -Dorg.gradle.unsafe.isolated-projects=true

- Before: `BUILD FAILED` with the error quoted above.
- After: `BUILD SUCCESSFUL`, configuration cache entry stored.

Also verified end-to-end with the iOS link task; no further isolation
violations surfaced in the configuration-cache report:

./gradlew :shared:linkDebugFrameworkIosArm64 -Dorg.gradle.unsafe.isolated-projects=true