### PR TITLE
Massive migration from context receivers to context parameters

### DIFF
--- a/SKIE/acceptance-tests/framework/src/main/kotlin/co/touchlab/skie/acceptancetests/framework/internal/skie/VerifyFrameworkHeaderPhase.kt
+++ b/SKIE/acceptance-tests/framework/src/main/kotlin/co/touchlab/skie/acceptancetests/framework/internal/skie/VerifyFrameworkHeaderPhase.kt
@@ -34,33 +34,33 @@ object VerifyFrameworkHeaderPhase : SirPhase {
 
     private const val className = "HeaderVerification"
 
-    context(SirPhase.Context)
-    override fun isActive(): Boolean = globalConfiguration[TestConfigurationKeys.EnableVerifyFrameworkHeaderPhase]
+    context(context: SirPhase.Context)
+    override fun isActive(): Boolean = context.globalConfiguration[TestConfigurationKeys.EnableVerifyFrameworkHeaderPhase]
 
-    context(SirPhase.Context)
+    context(context: SirPhase.Context)
     override suspend fun execute() {
-        val headerValidationSwiftFilePath = globalConfiguration[TestConfigurationKeys.VerifyFrameworkHeaderPhaseSwiftFilePath]
+        val headerValidationSwiftFilePath = context.globalConfiguration[TestConfigurationKeys.VerifyFrameworkHeaderPhaseSwiftFilePath]
 
         val fileContent = generateFileContent()
 
         headerValidationSwiftFilePath.writeText(fileContent)
     }
 
-    context(SirPhase.Context)
+    context(context: SirPhase.Context)
     private fun generateFileContent(): String {
         // Not used outside of this file; therefore it's intentionally not included in SirProvider
         val sirModule = SirModule.Skie(className)
 
         val sirFile = SirIrFile(sirModule, Path("$className.swift"))
 
-        sirFile.imports.add(framework.frameworkName)
+        sirFile.imports.add(context.framework.frameworkName)
 
         sirFile.addVerificationFileBody()
 
         return SirCodeGenerator.generate(sirFile)
     }
 
-    context(SirPhase.Context)
+    context(context: SirPhase.Context)
     private fun SirIrFile.addVerificationFileBody() {
         SirClass(
             baseName = className,
@@ -70,9 +70,9 @@ object VerifyFrameworkHeaderPhase : SirPhase {
         }
     }
 
-    context(SirPhase.Context, SirClass)
+    context(context: SirPhase.Context, sirClass: SirClass)
     private fun addVerificationClassBody() {
-        sirProvider.allLocalCallableDeclarations
+        context.sirProvider.allLocalCallableDeclarations
             .filter { it.visibility.isAccessibleFromOtherModules }
             .filter { it.findFirstSkieErrorType() == null }
             .forEach {
@@ -80,7 +80,7 @@ object VerifyFrameworkHeaderPhase : SirPhase {
             }
     }
 
-    context(SirClass, SirPhase.Context)
+    context(sirClass: SirClass, context: SirPhase.Context)
     private fun addCallableDeclarationVerification(callableDeclaration: SirCallableDeclaration) {
         when (callableDeclaration) {
             is SirConstructor -> addConstructorVerification(callableDeclaration)
@@ -89,7 +89,7 @@ object VerifyFrameworkHeaderPhase : SirPhase {
         }
     }
 
-    context(SirClass)
+    context(sirClass: SirClass)
     private fun addConstructorVerification(constructor: SirConstructor) {
         SirSimpleFunction(
             identifier = constructor.getVerificationFunctionIdentifier(),
@@ -116,11 +116,11 @@ object VerifyFrameworkHeaderPhase : SirPhase {
         }
     }
 
-    context(SirClass)
+    context(sirClass: SirClass)
     private fun addSimpleFunctionVerification(function: SirSimpleFunction) {
         function.shallowCopy(
             identifier = function.getVerificationFunctionIdentifier(),
-            parent = this@SirClass,
+            parent = sirClass,
             visibility = SirVisibility.Public,
             isReplaced = false,
             isHidden = false,
@@ -151,7 +151,7 @@ object VerifyFrameworkHeaderPhase : SirPhase {
         }
     }
 
-    context(SirClass, SirPhase.Context)
+    context(sirClass: SirClass, context: SirPhase.Context)
     private fun addPropertyVerification(property: SirProperty) {
         property.getter?.let {
             addPropertyGetterVerification(it)
@@ -163,7 +163,7 @@ object VerifyFrameworkHeaderPhase : SirPhase {
         }
     }
 
-    context(SirClass)
+    context(sirClass: SirClass)
     private fun addPropertyGetterVerification(getter: SirGetter) {
         val property = getter.property
 
@@ -190,13 +190,13 @@ object VerifyFrameworkHeaderPhase : SirPhase {
         }
     }
 
-    context(SirClass, SirPhase.Context)
+    context(sirClass: SirClass, context: SirPhase.Context)
     private fun addPropertySetterVerification(setter: SirSetter) {
         val property = setter.property
 
         SirSimpleFunction(
             identifier = property.getVerificationFunctionIdentifier(),
-            returnType = sirBuiltins.Swift.Void.defaultType,
+            returnType = context.sirBuiltins.Swift.Void.defaultType,
             deprecationLevel = property.deprecationLevel,
             throws = setter.throws,
             attributes = setter.attributes + property.attributes,
@@ -251,10 +251,10 @@ object VerifyFrameworkHeaderPhase : SirPhase {
         }
     }
 
-    context(SirClass)
-    private fun nextIndex(): Int = declarations.size
+    context(sirClass: SirClass)
+    private fun nextIndex(): Int = sirClass.declarations.size
 
-    context(SirClass)
+    context(sirClass: SirClass)
     private fun SirCallableDeclaration.getVerificationFunctionIdentifier(): String =
         (((this.parent as? SirDeclarationNamespace)?.fqName?.toLocalString()?.let { "${it}__" } ?: "") +
             this.identifierAfterVisibilityChange +

--- a/SKIE/acceptance-tests/framework/src/main/kotlin/co/touchlab/skie/acceptancetests/framework/internal/skie/VerifyTestPhasesAreExecutedPhase.kt
+++ b/SKIE/acceptance-tests/framework/src/main/kotlin/co/touchlab/skie/acceptancetests/framework/internal/skie/VerifyTestPhasesAreExecutedPhase.kt
@@ -4,9 +4,9 @@ import co.touchlab.skie.phases.SirPhase
 
 object VerifyTestPhasesAreExecutedPhase : SirPhase {
 
-    context(SirPhase.Context)
+    context(context: SirPhase.Context)
     override suspend fun execute() {
-        val shouldCrash = kirProvider.kotlinClasses.any { it.swiftName == "VerifySkieTestPhasesAreExecuted" }
+        val shouldCrash = context.kirProvider.kotlinClasses.any { it.swiftName == "VerifySkieTestPhasesAreExecuted" }
 
         if (shouldCrash) {
             error("Test phases are executed.")

--- a/SKIE/acceptance-tests/framework/src/main/kotlin/co/touchlab/skie/acceptancetests/framework/internal/testrunner/TestRunner.kt
+++ b/SKIE/acceptance-tests/framework/src/main/kotlin/co/touchlab/skie/acceptancetests/framework/internal/testrunner/TestRunner.kt
@@ -81,13 +81,13 @@ internal class TestRunner(
             ),
         )
 
-    context(TempFileSystem)
+    context(tempFileSystem: TempFileSystem)
     private fun withJvmInlineAnnotation(
         kotlinFiles: List<Path>,
     ): List<Path> {
         val packageRegex = Regex("package (.*)\\n")
 
-        val kotlinDirectory = createDirectory("kotlin")
+        val kotlinDirectory = tempFileSystem.createDirectory("kotlin")
 
         val jvmInlineFiles = kotlinFiles
             .mapNotNull { packageRegex.find(it.readText())?.groupValues?.getOrNull(1) }
@@ -106,43 +106,43 @@ internal class TestRunner(
         return kotlinFiles + jvmInlineFiles
     }
 
-    context(TempFileSystem, TestLogger)
+    context(tempFileSystem: TempFileSystem, testLogger: TestLogger)
     private fun compileKotlin(
         kotlinFiles: List<Path>,
         compilerArgumentsProvider: CompilerArgumentsProvider,
     ): IntermediateResult<Path> =
-        KotlinTestCompiler(this@TempFileSystem, this@TestLogger).compile(kotlinFiles, compilerArgumentsProvider)
+        KotlinTestCompiler(tempFileSystem, testLogger).compile(kotlinFiles, compilerArgumentsProvider)
 
-    context(TempFileSystem)
+    context(tempFileSystem: TempFileSystem)
     private fun generateConfiguration(
         baseConfiguration: CompilerSkieConfigurationData,
         configFiles: List<Path>,
     ): IntermediateResult<Path> =
-        PluginConfigurationGenerator(this@TempFileSystem).generate(baseConfiguration, configFiles)
+        PluginConfigurationGenerator(tempFileSystem).generate(baseConfiguration, configFiles)
 
-    context(TempFileSystem, TestLogger)
+    context(tempFileSystem: TempFileSystem, testLogger: TestLogger)
     private fun linkKotlin(
         klib: Path,
         skieConfigurationData: CompilerSkieConfigurationData,
         compilerArgumentsProvider: CompilerArgumentsProvider,
     ): IntermediateResult<Path> =
-        KotlinTestLinker(this@TempFileSystem, this@TestLogger).link(klib, skieConfigurationData, compilerArgumentsProvider)
+        KotlinTestLinker(tempFileSystem, testLogger).link(klib, skieConfigurationData, compilerArgumentsProvider)
 
-    context(TempFileSystem)
+    context(tempFileSystem: TempFileSystem)
     private fun enhanceSwiftCode(swiftCode: String): Path =
-        SwiftCodeEnhancer(this@TempFileSystem).enhance(swiftCode)
+        SwiftCodeEnhancer(tempFileSystem).enhance(swiftCode)
 
-    context(TempFileSystem, TestLogger)
+    context(tempFileSystem: TempFileSystem, testLogger: TestLogger)
     private fun compileSwift(
         kotlinFramework: Path,
         swiftFiles: List<Path>,
         compilerArgumentsProvider: CompilerArgumentsProvider,
     ): IntermediateResult<Path> =
-        SwiftTestCompiler(this@TempFileSystem, this@TestLogger, compilerArgumentsProvider.target).compile(kotlinFramework, swiftFiles)
+        SwiftTestCompiler(tempFileSystem, testLogger, compilerArgumentsProvider.target).compile(kotlinFramework, swiftFiles)
 
-    context(TestLogger)
+    context(testLogger: TestLogger)
     private fun runSwift(binary: Path): TestResult =
-        SwiftProgramRunner(this@TestLogger).runProgram(binary)
+        SwiftProgramRunner(testLogger).runProgram(binary)
 
     private fun writeResult(test: TestNode.Test, result: TestResultWithLogs) {
         val resultAsText = result.hasSucceededAsString(test)

--- a/SKIE/acceptance-tests/type-mapping/src/test/kotlin/co/touchlab/skie/kotlingenerator/KotlinGenerator.kt
+++ b/SKIE/acceptance-tests/type-mapping/src/test/kotlin/co/touchlab/skie/kotlingenerator/KotlinGenerator.kt
@@ -30,14 +30,14 @@ object KotlinGenerator {
         }
     }
 
-    context(Context)
+    context(context: Context)
     private fun SmartStringBuilder.append(file: KotlinFile) {
         file.declarations.forEach {
             append(it)
         }
     }
 
-    context(Context)
+    context(context: Context)
     private fun SmartStringBuilder.append(declaration: KotlinDeclaration) {
         +""
 
@@ -48,7 +48,7 @@ object KotlinGenerator {
         }
     }
 
-    context(Context)
+    context(context: Context)
     private fun SmartStringBuilder.append(clazz: KotlinClass) {
         when (clazz.kind) {
             KotlinClass.Kind.Class -> append("class ")
@@ -70,14 +70,14 @@ object KotlinGenerator {
         +"}"
     }
 
-    context(Context)
+    context(context: Context)
     private fun SmartStringBuilder.appendTypeParameters(clazz: KotlinClass) {
         when (clazz.typeParameters.size) {
             0 -> {}
             1 -> {
                 val typeParameter = clazz.typeParameters.single()
 
-                typeParameter.bounds.forEach { registerType(it) }
+                typeParameter.bounds.forEach { context.registerType(it) }
 
                 append("<${typeParameter.name}")
                 appendSingleBound(typeParameter)
@@ -88,7 +88,7 @@ object KotlinGenerator {
 
                 indented {
                     clazz.typeParameters.forEach { typeParameter ->
-                        typeParameter.bounds.forEach { registerType(it) }
+                        typeParameter.bounds.forEach { context.registerType(it) }
 
                         append(typeParameter.name)
                         appendSingleBound(typeParameter)
@@ -103,14 +103,14 @@ object KotlinGenerator {
         appendWhere(clazz)
     }
 
-    context(Context)
+    context(context: Context)
     private fun SmartStringBuilder.appendSingleBound(typeParameter: KotlinTypeParameter) {
         if (typeParameter.bounds.size == 1) {
             append(" : ${typeParameter.bounds.single().toKotlinName()}")
         }
     }
 
-    context(Context)
+    context(context: Context)
     private fun SmartStringBuilder.appendWhere(clazz: KotlinClass) {
         val typeParametersWithBounds = clazz.typeParameters
             .filter { it.bounds.size > 1 }
@@ -129,13 +129,13 @@ object KotlinGenerator {
         }
     }
 
-    context(Context)
+    context(context: Context)
     private fun SmartStringBuilder.append(function: KotlinFunction) {
-        function.extensionReceiver?.let { registerType(it) }
+        function.extensionReceiver?.let { context.registerType(it) }
         function.valueParameters.forEach {
-            registerType(it.type)
+            context.registerType(it.type)
         }
-        registerType(function.returnType)
+        context.registerType(function.returnType)
 
         function.annotations.forEach {
             +it
@@ -152,9 +152,9 @@ object KotlinGenerator {
         +"}"
     }
 
-    context(Context)
+    context(context: Context)
     private fun SmartStringBuilder.append(property: KotlinProperty) {
-        registerType(property.type)
+        context.registerType(property.type)
 
         +"val ${property.name}: ${property.type.toKotlinName()} = ${property.initializer}"
     }

--- a/SKIE/acceptance-tests/type-mapping/src/test/kotlin/co/touchlab/skie/test/TestFileGenerationPhase.kt
+++ b/SKIE/acceptance-tests/type-mapping/src/test/kotlin/co/touchlab/skie/test/TestFileGenerationPhase.kt
@@ -23,12 +23,12 @@ import io.outfoxx.swiftpoet.parameterizedBy
 
 object TestFileGenerationPhase : SirPhase {
 
-    context(SirPhase.Context)
+    context(context: SirPhase.Context)
     override suspend fun execute() {
-        val kirClass = kirProvider.getClassByFqName("co.touchlab.skie.test.KotlinFile")
+        val kirClass = context.kirProvider.getClassByFqName("co.touchlab.skie.test.KotlinFile")
         val sirClass = kirClass.originalSirClass
 
-        namespaceProvider.getSkieNamespaceWrittenSourceFile("TypeVerification").content = """
+        context.namespaceProvider.getSkieNamespaceWrittenSourceFile("TypeVerification").content = """
                 @resultBuilder
                 struct VerifyReturnType<ReturnType> {
                     let value: ReturnType
@@ -62,7 +62,7 @@ object TestFileGenerationPhase : SirPhase {
 
         val swiftFileBuilders = mutableListOf<FileSpec.Builder>()
 
-        FileSpec.builder(framework.frameworkName, "TypeVerification+verify")
+        FileSpec.builder(context.framework.frameworkName, "TypeVerification+verify")
             .also { swiftFileBuilders.add(it) }
             .apply {
                 val parameterCounts = kirClass.callableDeclarations
@@ -125,7 +125,7 @@ object TestFileGenerationPhase : SirPhase {
                 }
             }
 
-        FileSpec.builder(framework.frameworkName, "KotlinFile_access")
+        FileSpec.builder(context.framework.frameworkName, "KotlinFile_access")
             .also { swiftFileBuilders.add(it) }
             .apply {
                 addImport("Foundation")
@@ -232,7 +232,7 @@ object TestFileGenerationPhase : SirPhase {
         swiftFileBuilders.forEach { builder ->
             val file = builder.build()
 
-            namespaceProvider.getSkieNamespaceWrittenSourceFile(file.name).content = file.toString()
+            context.namespaceProvider.getSkieNamespaceWrittenSourceFile(file.name).content = file.toString()
         }
     }
 }

--- a/SKIE/kotlin-compiler/core/src/main/kotlin/co/touchlab/skie/configuration/SimpleFunctionConfiguration.kt
+++ b/SKIE/kotlin-compiler/core/src/main/kotlin/co/touchlab/skie/configuration/SimpleFunctionConfiguration.kt
@@ -21,6 +21,6 @@ class SimpleFunctionConfiguration(
     }
 }
 
-context(CommonSkieContext)
+context(commonSkieContext: CommonSkieContext)
 val SimpleFunctionConfiguration.isSuspendInteropEnabled: Boolean
-    get() = SkieConfigurationFlag.Feature_CoroutinesInterop.isEnabled && this[SuspendInterop.Enabled]
+    get() = commonSkieContext.run { SkieConfigurationFlag.Feature_CoroutinesInterop.isEnabled } && this[SuspendInterop.Enabled]

--- a/SKIE/kotlin-compiler/core/src/main/kotlin/co/touchlab/skie/kir/type/SupportedFlow.kt
+++ b/SKIE/kotlin-compiler/core/src/main/kotlin/co/touchlab/skie/kir/type/SupportedFlow.kt
@@ -24,8 +24,8 @@ enum class SupportedFlow(private val directParent: SupportedFlow?) {
     fun getCoroutinesKirClass(kirProvider: KirProvider): KirClass =
         kirProvider.getClassByFqName(coroutinesFlowFqName)
 
-    context(SirPhase.Context)
-    fun getCoroutinesKirClass(): KirClass = getCoroutinesKirClass(kirProvider)
+    context(context: SirPhase.Context)
+    fun getCoroutinesKirClass(): KirClass = getCoroutinesKirClass(context.kirProvider)
 
     sealed interface Variant {
 
@@ -42,14 +42,14 @@ enum class SupportedFlow(private val directParent: SupportedFlow?) {
 
         fun getSwiftClass(sirProvider: SirProvider): SirClass
 
-        context(SirPhase.Context)
-        fun getCoroutinesKirClass(): KirClass = getCoroutinesKirClass(kirProvider)
+        context(context: SirPhase.Context)
+        fun getCoroutinesKirClass(): KirClass = getCoroutinesKirClass(context.kirProvider)
 
-        context(SirPhase.Context)
-        fun getKotlinKirClass(): KirClass = getKotlinKirClass(kirProvider)
+        context(context: SirPhase.Context)
+        fun getKotlinKirClass(): KirClass = getKotlinKirClass(context.kirProvider)
 
-        context(SirPhase.Context)
-        fun getSwiftClass(): SirClass = getSwiftClass(sirProvider)
+        context(context: SirPhase.Context)
+        fun getSwiftClass(): SirClass = getSwiftClass(context.sirProvider)
 
         fun isCastableTo(variant: Variant): Boolean
 

--- a/SKIE/kotlin-compiler/core/src/main/kotlin/co/touchlab/skie/phases/ScheduledPhase.kt
+++ b/SKIE/kotlin-compiler/core/src/main/kotlin/co/touchlab/skie/phases/ScheduledPhase.kt
@@ -7,10 +7,10 @@ import co.touchlab.skie.util.directory.FrameworkLayout
 
 interface ScheduledPhase<C : ScheduledPhase.Context> {
 
-    context(C)
+    context(c: C)
     fun isActive(): Boolean = true
 
-    context(C)
+    context(c: C)
     suspend fun execute()
 
     interface Context : CommonSkieContext {

--- a/SKIE/kotlin-compiler/core/src/main/kotlin/co/touchlab/skie/phases/SkiePhaseScheduler.kt
+++ b/SKIE/kotlin-compiler/core/src/main/kotlin/co/touchlab/skie/phases/SkiePhaseScheduler.kt
@@ -19,37 +19,37 @@ interface SkiePhaseScheduler {
 
     val linkPhases: SkiePhaseGroup<LinkPhase, LinkPhase.Context>
 
-    context(ScheduledPhase.Context)
+    context(context: ScheduledPhase.Context)
     fun runClassExportPhases(contextFactory: () -> ClassExportPhase.Context) {
         classExportPhases.run(contextFactory)
     }
 
-    context(ScheduledPhase.Context)
+    context(context: ScheduledPhase.Context)
     fun runFrontendIrPhases(contextFactory: () -> FrontendIrPhase.Context) {
         frontendIrPhases.run(contextFactory)
     }
 
-    context(ScheduledPhase.Context)
+    context(context: ScheduledPhase.Context)
     fun runSymbolTablePhases(contextFactory: () -> SymbolTablePhase.Context) {
         symbolTablePhases.run(contextFactory)
     }
 
-    context(ScheduledPhase.Context)
+    context(context: ScheduledPhase.Context)
     fun runKotlinIrPhases(contextFactory: () -> KotlinIrPhase.Context) {
         kotlinIrPhases.run(contextFactory)
     }
 
-    context(ScheduledPhase.Context)
+    context(context: ScheduledPhase.Context)
     fun runKirPhases(contextFactory: () -> KirPhase.Context) {
         kirPhases.run(contextFactory)
     }
 
-    context(ScheduledPhase.Context)
+    context(context: ScheduledPhase.Context)
     fun runSirPhases(contextFactory: () -> SirPhase.Context) {
         sirPhases.run(contextFactory)
     }
 
-    context(ScheduledPhase.Context)
+    context(context: ScheduledPhase.Context)
     fun runLinkPhases(contextFactory: () -> LinkPhase.Context) {
         linkPhases.run(contextFactory)
     }

--- a/SKIE/kotlin-compiler/core/src/main/kotlin/co/touchlab/skie/phases/analytics/LogSkiePerformanceAnalyticsPhase.kt
+++ b/SKIE/kotlin-compiler/core/src/main/kotlin/co/touchlab/skie/phases/analytics/LogSkiePerformanceAnalyticsPhase.kt
@@ -5,8 +5,8 @@ import co.touchlab.skie.phases.LinkPhase
 // Cannot run in the background otherwise there is a risk of a deadlock
 object LogSkiePerformanceAnalyticsPhase : LinkPhase {
 
-    context(LinkPhase.Context)
+    context(context: LinkPhase.Context)
     override suspend fun execute() {
-        analyticsCollector.collectSynchronously(skiePerformanceAnalyticsProducer)
+        context.analyticsCollector.collectSynchronously(context.skiePerformanceAnalyticsProducer)
     }
 }

--- a/SKIE/kotlin-compiler/core/src/main/kotlin/co/touchlab/skie/phases/apinotes/ApiNotesGenerationPhase.kt
+++ b/SKIE/kotlin-compiler/core/src/main/kotlin/co/touchlab/skie/phases/apinotes/ApiNotesGenerationPhase.kt
@@ -10,34 +10,34 @@ sealed class ApiNotesGenerationPhase(
     private val exposeInternalMembers: Boolean,
 ) : SirPhase {
 
-    context(SirPhase.Context)
+    context(context: SirPhase.Context)
     override suspend fun execute() {
         val apiNotes = ApiNotesFactory(exposeInternalMembers).create()
 
         apiNotes.createApiNotesFile()
     }
 
-    context(SirPhase.Context)
+    context(context: SirPhase.Context)
     private fun ApiNotes.createApiNotesFile() {
         val content = this.createApiNotesFileContent()
 
         getApiNotesFile().writeTextIfDifferent(content)
     }
 
-    context(SirPhase.Context)
+    context(context: SirPhase.Context)
     protected abstract fun getApiNotesFile(): File
 
     object ForSwiftCompilation : ApiNotesGenerationPhase(true) {
 
-        context(SirPhase.Context)
+        context(context: SirPhase.Context)
         override fun getApiNotesFile(): File =
-            skieBuildDirectory.swiftCompiler.apiNotes.apiNotes(framework.frameworkName)
+            context.skieBuildDirectory.swiftCompiler.apiNotes.apiNotes(context.framework.frameworkName)
     }
 
     object ForFramework : ApiNotesGenerationPhase(false) {
 
-        context(SirPhase.Context)
+        context(context: SirPhase.Context)
         override fun getApiNotesFile(): File =
-            framework.apiNotes
+            context.framework.apiNotes
     }
 }

--- a/SKIE/kotlin-compiler/core/src/main/kotlin/co/touchlab/skie/phases/apinotes/MoveBridgesToTopLevelPhase.kt
+++ b/SKIE/kotlin-compiler/core/src/main/kotlin/co/touchlab/skie/phases/apinotes/MoveBridgesToTopLevelPhase.kt
@@ -11,9 +11,9 @@ import co.touchlab.skie.sir.element.toTypeFromEnclosingTypeParameters
 // Needed due to a bug in Swift compiler that incorrectly resolves bridges nested in other declarations.
 object MoveBridgesToTopLevelPhase : SirPhase {
 
-    context(SirPhase.Context)
+    context(context: SirPhase.Context)
     override suspend fun execute() {
-        kirProvider.kotlinClasses
+        context.kirProvider.kotlinClasses
             .mapNotNull { it.bridgedSirClass }
             .forEach {
                 it.moveToTopLevel()

--- a/SKIE/kotlin-compiler/core/src/main/kotlin/co/touchlab/skie/phases/apinotes/builder/ApiNotesFactory.kt
+++ b/SKIE/kotlin-compiler/core/src/main/kotlin/co/touchlab/skie/phases/apinotes/builder/ApiNotesFactory.kt
@@ -16,15 +16,15 @@ class ApiNotesFactory(
     private val exposeInternalMembers: Boolean,
 ) {
 
-    context(SirPhase.Context)
+    context(context: SirPhase.Context)
     fun create(): ApiNotes =
         ApiNotes(
-            moduleName = framework.frameworkName,
-            classes = oirProvider.kotlinClasses.map { it.toApiNote() },
-            protocols = oirProvider.kotlinProtocols.map { it.toApiNote() },
+            moduleName = context.framework.frameworkName,
+            classes = context.oirProvider.kotlinClasses.map { it.toApiNote() },
+            protocols = context.oirProvider.kotlinProtocols.map { it.toApiNote() },
         )
 
-    context(SirPhase.Context)
+    context(context: SirPhase.Context)
     private fun OirClass.toApiNote(): ApiNotesType =
         ApiNotesType(
             objCFqName = this.name,
@@ -36,7 +36,7 @@ class ApiNotesFactory(
             properties = this.callableDeclarationsIncludingExtensions.filterIsInstance<OirProperty>().filterNot { it.isFakeOverride }.map { it.toApiNote() },
         )
 
-    context(SirPhase.Context)
+    context(context: SirPhase.Context)
     private fun OirFunction.toApiNote(): ApiNotesMethod =
         ApiNotesMethod(
             objCSelector = this.selector,
@@ -52,14 +52,14 @@ class ApiNotesFactory(
             parameters = this.valueParameters.filter { it.originalSirValueParameter != null }.map { it.toApiNote() },
         )
 
-    context(SirPhase.Context)
+    context(context: SirPhase.Context)
     private fun OirValueParameter.toApiNote(): ApiNotesParameter =
         ApiNotesParameter(
             position = this.index,
             type = this.type.render(),
         )
 
-    context(SirPhase.Context)
+    context(context: SirPhase.Context)
     private fun OirProperty.toApiNote(): ApiNotesProperty =
         ApiNotesProperty(
             objCName = this.name,

--- a/SKIE/kotlin-compiler/core/src/main/kotlin/co/touchlab/skie/phases/bridging/CustomMembersPassthroughGenerator.kt
+++ b/SKIE/kotlin-compiler/core/src/main/kotlin/co/touchlab/skie/phases/bridging/CustomMembersPassthroughGenerator.kt
@@ -14,7 +14,7 @@ import io.outfoxx.swiftpoet.joinToCode
 
 object CustomMembersPassthroughGenerator {
 
-    context(SirPhase.Context)
+    context(context: SirPhase.Context)
     fun generatePassthroughForDeclarations(
         targetBridge: SirClass,
         declarations: List<CustomPassthroughDeclaration>,
@@ -25,7 +25,7 @@ object CustomMembersPassthroughGenerator {
         }
     }
 
-    context(SirPhase.Context)
+    context(context: SirPhase.Context)
     private fun SirClass.addPassthroughForDeclaration(declaration: CustomPassthroughDeclaration, delegateAccessor: CodeBlock) {
         when (declaration) {
             is CustomPassthroughDeclaration.SimpleFunction -> addPassthroughForFunction(declaration, delegateAccessor)
@@ -33,7 +33,7 @@ object CustomMembersPassthroughGenerator {
         }
     }
 
-    context(SirPhase.Context)
+    context(context: SirPhase.Context)
     private fun SirClass.addPassthroughForFunction(function: CustomPassthroughDeclaration.SimpleFunction, delegateAccessor: CodeBlock) {
         SirSimpleFunction(
             identifier = function.identifier,
@@ -91,7 +91,7 @@ object CustomMembersPassthroughGenerator {
         )
     }
 
-    context(SirPhase.Context)
+    context(context: SirPhase.Context)
     private fun SirClass.addPassthroughForProperty(property: CustomPassthroughDeclaration.Property, delegateAccessor: CodeBlock) {
         SirProperty(
             identifier = property.identifier,

--- a/SKIE/kotlin-compiler/core/src/main/kotlin/co/touchlab/skie/phases/bridging/DirectMembersPassthroughGenerator.kt
+++ b/SKIE/kotlin-compiler/core/src/main/kotlin/co/touchlab/skie/phases/bridging/DirectMembersPassthroughGenerator.kt
@@ -26,7 +26,7 @@ object DirectMembersPassthroughGenerator {
     private val SirSimpleFunction.isSupported: Boolean
         get() = this.name !in unsupportedFunctionNames
 
-    context(SirPhase.Context)
+    context(context: SirPhase.Context)
     fun generatePassthroughForMembers(
         targetBridge: SirClass,
         bridgedKirClass: KirClass,
@@ -38,7 +38,7 @@ object DirectMembersPassthroughGenerator {
             }
     }
 
-    context(SirPhase.Context)
+    context(context: SirPhase.Context)
     private fun SirClass.addPassthroughForMember(member: KirCallableDeclaration<*>, delegateAccessor: CodeBlock) {
         when (member) {
             is KirConstructor -> {
@@ -49,7 +49,7 @@ object DirectMembersPassthroughGenerator {
         }
     }
 
-    context(SirPhase.Context)
+    context(context: SirPhase.Context)
     private fun SirClass.addPassthroughForFunction(function: KirSimpleFunction, delegateAccessor: CodeBlock) {
         function.forEachAssociatedExportedSirDeclaration {
             addPassthroughForFunction(it, delegateAccessor)
@@ -80,7 +80,7 @@ object DirectMembersPassthroughGenerator {
         }
     }
 
-    context(SirPhase.Context)
+    context(context: SirPhase.Context)
     private fun SirClass.addPassthroughForProperty(property: KirProperty, delegateAccessor: CodeBlock) {
         property.forEachAssociatedExportedSirDeclaration {
             addPassthroughForProperty(it, delegateAccessor)

--- a/SKIE/kotlin-compiler/core/src/main/kotlin/co/touchlab/skie/phases/bridging/ObjCBridgeableGenerator.kt
+++ b/SKIE/kotlin-compiler/core/src/main/kotlin/co/touchlab/skie/phases/bridging/ObjCBridgeableGenerator.kt
@@ -19,7 +19,7 @@ object ObjCBridgeableGenerator {
     /**
      * @param unwrapObjectiveCSource Whether to add `guard let` to crash on `nil` source in `fromObjectiveC`.
      */
-    context(SirPhase.Context)
+    context(context: SirPhase.Context)
     fun addObjcBridgeableImplementation(
         target: SirClass,
         bridgedType: SirType,
@@ -38,20 +38,20 @@ object ObjCBridgeableGenerator {
     private val SirClass.toTypeWithGenericParameters: SirDeclaredSirType
         get() = this.toType(this.typeParameters.map { it.toTypeParameterUsage() })
 
-    context(SirPhase.Context)
+    context(context: SirPhase.Context)
     private fun SirClass.addObjectiveCTypeAlias(bridgedType: SirType) {
         SirTypeAlias(
-            baseName = sirBuiltins.Swift._ObjectiveCBridgeable.typeParameters.first().name,
+            baseName = context.sirBuiltins.Swift._ObjectiveCBridgeable.typeParameters.first().name,
         ) {
             bridgedType
         }
     }
 
-    context(SirPhase.Context)
+    context(context: SirPhase.Context)
     private fun SirClass.addForceBridgeFromObjectiveC(bridgedType: SirType) {
         SirSimpleFunction(
             identifier = "_forceBridgeFromObjectiveC",
-            returnType = sirBuiltins.Swift.Void.defaultType,
+            returnType = context.sirBuiltins.Swift.Void.defaultType,
             scope = SirScope.Static,
         ).apply {
             SirValueParameter(
@@ -72,11 +72,11 @@ object ObjCBridgeableGenerator {
         }
     }
 
-    context(SirPhase.Context)
+    context(context: SirPhase.Context)
     private fun SirClass.addConditionallyBridgeFromObjectiveC(bridgedType: SirType) {
         SirSimpleFunction(
             identifier = "_conditionallyBridgeFromObjectiveC",
-            returnType = sirBuiltins.Swift.Bool.defaultType,
+            returnType = context.sirBuiltins.Swift.Bool.defaultType,
             scope = SirScope.Static,
         ).apply {
             SirValueParameter(

--- a/SKIE/kotlin-compiler/core/src/main/kotlin/co/touchlab/skie/phases/debug/DumpSwiftApiPhase.kt
+++ b/SKIE/kotlin-compiler/core/src/main/kotlin/co/touchlab/skie/phases/debug/DumpSwiftApiPhase.kt
@@ -11,27 +11,27 @@ sealed class DumpSwiftApiPhase : SirPhase {
 
     object BeforeApiNotes : DumpSwiftApiPhase() {
 
-        context(SirPhase.Context)
-        override fun isActive(): Boolean = SkieConfigurationFlag.Debug_DumpSwiftApiBeforeApiNotes.isEnabled
+        context(context: SirPhase.Context)
+        override fun isActive(): Boolean = with(context) { SkieConfigurationFlag.Debug_DumpSwiftApiBeforeApiNotes.isEnabled }
     }
 
     object AfterApiNotes : DumpSwiftApiPhase() {
 
-        context(SirPhase.Context)
-        override fun isActive(): Boolean = SkieConfigurationFlag.Debug_DumpSwiftApiAfterApiNotes.isEnabled
+        context(context: SirPhase.Context)
+        override fun isActive(): Boolean = with(context) { SkieConfigurationFlag.Debug_DumpSwiftApiAfterApiNotes.isEnabled }
     }
 
-    context(SirPhase.Context)
+    context(context: SirPhase.Context)
     override suspend fun execute() {
-        val moduleName = framework.frameworkName
+        val moduleName = context.framework.frameworkName
         val apiFileBaseName = "${moduleName}_${this::class.simpleName}"
-        val apiFile = skieBuildDirectory.debug.dumps.apiFile(apiFileBaseName)
-        val logFile = skieBuildDirectory.debug.logs.apiFile(apiFileBaseName)
+        val apiFile = context.skieBuildDirectory.debug.dumps.apiFile(apiFileBaseName)
+        val logFile = context.skieBuildDirectory.debug.logs.apiFile(apiFileBaseName)
 
         val command = Command(
             "zsh",
             "-c",
-            """echo "import Kotlin\n:type lookup $moduleName" | swift repl -F "${framework.frameworkDirectory.parentFile.absolutePath}" > "${apiFile.absolutePath}"""",
+            """echo "import Kotlin\n:type lookup $moduleName" | swift repl -F "${context.framework.frameworkDirectory.parentFile.absolutePath}" > "${apiFile.absolutePath}"""",
         )
 
         try {

--- a/SKIE/kotlin-compiler/core/src/main/kotlin/co/touchlab/skie/phases/features/defaultarguments/RemoveConflictingDefaultArgumentOverloadsPhase.kt
+++ b/SKIE/kotlin-compiler/core/src/main/kotlin/co/touchlab/skie/phases/features/defaultarguments/RemoveConflictingDefaultArgumentOverloadsPhase.kt
@@ -13,9 +13,9 @@ import co.touchlab.skie.sir.signature.SirHierarchyCache
 
 object RemoveConflictingDefaultArgumentOverloadsPhase : SirPhase {
 
-    context(SirPhase.Context)
+    context(context: SirPhase.Context)
     override suspend fun execute() {
-        val allBaseFunctions = kirProvider.kotlinConstructors + kirProvider.kotlinSimpleFunctions.filter { it.isBaseDeclaration }
+        val allBaseFunctions = context.kirProvider.kotlinConstructors + context.kirProvider.kotlinSimpleFunctions.filter { it.isBaseDeclaration }
 
         val allDefaultArgumentOverloads = allBaseFunctions.flatMap { it.defaultArgumentsOverloads }.toSet()
 

--- a/SKIE/kotlin-compiler/core/src/main/kotlin/co/touchlab/skie/phases/features/enums/EnumEntryRenamingPhase.kt
+++ b/SKIE/kotlin-compiler/core/src/main/kotlin/co/touchlab/skie/phases/features/enums/EnumEntryRenamingPhase.kt
@@ -32,9 +32,9 @@ object EnumEntryRenamingPhase : SirPhase {
         "useStoredAccessor",
     )
 
-    context(SirPhase.Context)
+    context(context: SirPhase.Context)
     override suspend fun execute() {
-        kirProvider.kotlinEnums
+        context.kirProvider.kotlinEnums
             .filter { it.isSupported }
             .forEach {
                 it.renameEnumEntries()
@@ -47,7 +47,7 @@ object EnumEntryRenamingPhase : SirPhase {
     private val KirEnumEntry.isSupported: Boolean
         get() = !this.hasUserDefinedName
 
-    context(SirPhase.Context)
+    context(context: SirPhase.Context)
     private fun KirClass.renameEnumEntries() {
         this.enumEntries
             .filter { it.isSupported }

--- a/SKIE/kotlin-compiler/core/src/main/kotlin/co/touchlab/skie/phases/features/enums/ExhaustiveEnumsGenerator.kt
+++ b/SKIE/kotlin-compiler/core/src/main/kotlin/co/touchlab/skie/phases/features/enums/ExhaustiveEnumsGenerator.kt
@@ -23,26 +23,26 @@ import co.touchlab.skie.sir.getExtension
 
 object ExhaustiveEnumsGenerator : SirPhase {
 
-    context(SirPhase.Context)
+    context(context: SirPhase.Context)
     override suspend fun execute() {
-        kirProvider.kotlinClasses
+        context.kirProvider.kotlinClasses
             .filter { it.isSupported }
             .forEach {
                 generate(it)
             }
     }
 
-    context(SirPhase.Context)
+    context(context: SirPhase.Context)
     private val KirClass.isSupported: Boolean
         get() = this.originalSirClass.isExported &&
             this.kind == KirClass.Kind.Enum &&
             this.isEnumInteropEnabled
 
-    context(SirPhase.Context)
+    context(context: SirPhase.Context)
     private val KirClass.isEnumInteropEnabled: Boolean
         get() = this.configuration[EnumInterop.Enabled]
 
-    context(SirPhase.Context)
+    context(context: SirPhase.Context)
     private fun generate(kirClass: KirClass) {
         val skieClass = kirClass.generateBridge()
 
@@ -62,7 +62,7 @@ private fun KirClass.configureBridging(skieClass: SirClass) {
     originalSirClass.isReplaced = true
 }
 
-context(SirPhase.Context)
+context(context: SirPhase.Context)
 private fun KirClass.generateBridge(): SirClass {
     val bridgedEnum = createBridgingEnum(this)
 
@@ -71,24 +71,24 @@ private fun KirClass.generateBridge(): SirClass {
     return bridgedEnum
 }
 
-context(SirPhase.Context)
+context(context: SirPhase.Context)
 private fun createBridgingEnum(enumKirClass: KirClass): SirClass =
     SirClass(
         baseName = enumKirClass.originalSirClass.baseName,
         parent = enumKirClass.originalSirClass.namespace?.let { namespace ->
-            sirProvider.getExtension(
+            context.sirProvider.getExtension(
                 classDeclaration = namespace.classDeclaration,
-                parent = namespaceProvider.getNamespaceFile(enumKirClass),
+                parent = context.namespaceProvider.getNamespaceFile(enumKirClass),
             )
-        } ?: namespaceProvider.getNamespaceFile(enumKirClass),
+        } ?: context.namespaceProvider.getNamespaceFile(enumKirClass),
         kind = SirClass.Kind.Enum,
     ).apply {
         addEnumCases(enumKirClass)
 
         superTypes += listOf(
-            sirBuiltins.Swift.Hashable.defaultType,
-            sirBuiltins.Swift.CaseIterable.defaultType,
-            sirBuiltins.Swift._ObjectiveCBridgeable.defaultType,
+            context.sirBuiltins.Swift.Hashable.defaultType,
+            context.sirBuiltins.Swift.CaseIterable.defaultType,
+            context.sirBuiltins.Swift._ObjectiveCBridgeable.defaultType,
         )
 
         attributes.add("frozen")
@@ -96,7 +96,7 @@ private fun createBridgingEnum(enumKirClass: KirClass): SirClass =
         ExhaustiveEnumsMembersPassthroughGenerator.generatePassthroughForMembers(enumKirClass, this)
         ExhaustiveEnumsObjectiveCBridgeableGenerator.addObjcBridgeableImplementation(enumKirClass, this)
 
-        doInPhase(ExhaustiveEnumsGenerator.NestedTypeDeclarationsPhase) {
+        context.doInPhase(ExhaustiveEnumsGenerator.NestedTypeDeclarationsPhase) {
             addNestedClassTypeAliases(enumKirClass)
             addCompanionObjectPropertyIfNeeded(enumKirClass)
         }
@@ -146,15 +146,15 @@ private fun SirClass.addCompanionObjectPropertyIfNeeded(enum: KirClass) {
     }
 }
 
-context(SirPhase.Context)
+context(context: SirPhase.Context)
 private fun KirClass.addConversionExtensions(bridgedEnum: SirClass) {
-    namespaceProvider.getNamespaceFile(this).apply {
+    context.namespaceProvider.getNamespaceFile(this).apply {
         addToKotlinConversionExtension(originalSirClass, bridgedEnum)
         addToSwiftConversionExtension(originalSirClass, bridgedEnum)
     }
 }
 
-context(SirPhase.Context)
+context(context: SirPhase.Context)
 private fun SirIrFile.addToKotlinConversionExtension(enum: SirClass, bridgedEnum: SirClass) {
     this.getExtension(
         classDeclaration = bridgedEnum,
@@ -174,7 +174,7 @@ private fun SirExtension.addToKotlinConversionMethod(enum: SirClass) {
     }
 }
 
-context(SirPhase.Context)
+context(context: SirPhase.Context)
 private fun SirIrFile.addToSwiftConversionExtension(enum: SirClass, bridgedEnum: SirClass) {
     this.getExtension(
         classDeclaration = enum,
@@ -194,7 +194,7 @@ private fun SirExtension.addToSwiftConversionMethod(bridgedEnum: SirClass) {
     }
 }
 
-context(SirPhase.Context)
+context(context: SirPhase.Context)
 private fun createStableNameTypeAliasIfRequested(bridgedEnum: SirClass, kirClass: KirClass) {
     if (!kirClass.hasStableNameTypeAlias) {
         return
@@ -202,14 +202,14 @@ private fun createStableNameTypeAliasIfRequested(bridgedEnum: SirClass, kirClass
 
     val typeAlias = SirTypeAlias(
         baseName = "Enum",
-        parent = namespaceProvider.getNamespaceExtension(kirClass),
+        parent = context.namespaceProvider.getNamespaceExtension(kirClass),
         isReplaced = true,
         isHidden = true,
     ) {
         bridgedEnum.toFqNameType()
     }
 
-    if (SkieConfigurationFlag.Debug_UseStableTypeAliases.isEnabled) {
+    if (context.run { SkieConfigurationFlag.Debug_UseStableTypeAliases.isEnabled }) {
         bridgedEnum.internalTypeAlias = typeAlias
     }
 }

--- a/SKIE/kotlin-compiler/core/src/main/kotlin/co/touchlab/skie/phases/features/enums/ExhaustiveEnumsMembersPassthroughGenerator.kt
+++ b/SKIE/kotlin-compiler/core/src/main/kotlin/co/touchlab/skie/phases/features/enums/ExhaustiveEnumsMembersPassthroughGenerator.kt
@@ -8,7 +8,7 @@ import io.outfoxx.swiftpoet.CodeBlock
 
 object ExhaustiveEnumsMembersPassthroughGenerator {
 
-    context(SirPhase.Context)
+    context(context: SirPhase.Context)
     fun generatePassthroughForMembers(enumKirClass: KirClass, bridgedEnum: SirClass) {
         DirectMembersPassthroughGenerator.generatePassthroughForMembers(
             targetBridge = bridgedEnum,

--- a/SKIE/kotlin-compiler/core/src/main/kotlin/co/touchlab/skie/phases/features/enums/ExhaustiveEnumsObjectiveCBridgeableGenerator.kt
+++ b/SKIE/kotlin-compiler/core/src/main/kotlin/co/touchlab/skie/phases/features/enums/ExhaustiveEnumsObjectiveCBridgeableGenerator.kt
@@ -11,7 +11,7 @@ import io.outfoxx.swiftpoet.joinToCode
 
 object ExhaustiveEnumsObjectiveCBridgeableGenerator {
 
-    context(SirPhase.Context)
+    context(context: SirPhase.Context)
     fun addObjcBridgeableImplementation(enumKirClass: KirClass, bridgedEnum: SirClass) {
         ObjCBridgeableGenerator.addObjcBridgeableImplementation(
             target = bridgedEnum,

--- a/SKIE/kotlin-compiler/core/src/main/kotlin/co/touchlab/skie/phases/features/flow/ConvertFlowsPhase.kt
+++ b/SKIE/kotlin-compiler/core/src/main/kotlin/co/touchlab/skie/phases/features/flow/ConvertFlowsPhase.kt
@@ -27,7 +27,7 @@ class ConvertFlowsPhase(
 
     private val kirProvider = context.kirProvider
 
-    context(KirPhase.Context)
+    context(context: KirPhase.Context)
     override suspend fun execute() {
         kirProvider.kotlinClasses.forEach {
             it.convertFlows()
@@ -68,14 +68,14 @@ class ConvertFlowsPhase(
         convertFlowsInValueParameters()
     }
 
-    context(FlowMappingStrategy)
+    context(flowMappingStrategy: FlowMappingStrategy)
     private fun KirSimpleFunction.convertFlows() {
         convertFlowsInValueParameters()
 
         returnType = returnType.substituteFlows()
     }
 
-    context(FlowMappingStrategy)
+    context(flowMappingStrategy: FlowMappingStrategy)
     private fun KirProperty.convertFlows() {
         type = type.substituteFlows()
     }
@@ -92,7 +92,7 @@ class ConvertFlowsPhase(
         }
     }
 
-    context(FlowMappingStrategy)
+    context(flowMappingStrategy: FlowMappingStrategy)
     private fun KirType.substituteFlows(): KirType =
         when (this) {
             is NonNullReferenceKirType -> substituteFlows()
@@ -101,7 +101,7 @@ class ConvertFlowsPhase(
             is PointerKirType -> copy(pointee = pointee.substituteFlows())
         }
 
-    context(FlowMappingStrategy)
+    context(flowMappingStrategy: FlowMappingStrategy)
     private fun NonNullReferenceKirType.substituteFlows(): NonNullReferenceKirType =
         when (this) {
             is BlockPointerKirType -> copy(
@@ -113,30 +113,34 @@ class ConvertFlowsPhase(
             is TypeParameterUsageKirType -> this
         }
 
-    context(FlowMappingStrategy)
+    context(flowMappingStrategy: FlowMappingStrategy)
     private fun DeclarationBackedKirType.substituteFlows(): DeclaredKirType =
         when (this) {
             is DeclaredKirType -> {
-                declaration.withFlowMappingForTypeArguments {
-                    copy(typeArguments = typeArguments.map { it.substituteFlows() })
+                flowMappingStrategy.run {
+                    declaration.withFlowMappingForTypeArguments {
+                        copy(typeArguments = typeArguments.map { it.substituteFlows() })
+                    }
                 }
             }
             is UnresolvedFlowKirType -> resolve()
         }
 
-    context(FlowMappingStrategy)
+    context(flowMappingStrategy: FlowMappingStrategy)
     private fun UnresolvedFlowKirType.resolve(): DeclaredKirType =
-        when (this@FlowMappingStrategy) {
+        when (flowMappingStrategy) {
             FlowMappingStrategy.Full -> toSkieFlowType()
             FlowMappingStrategy.TypeArgumentsOnly, FlowMappingStrategy.None -> toCoroutinesFlowType()
         }
 
-    context(FlowMappingStrategy)
+    context(flowMappingStrategy: FlowMappingStrategy)
     private fun UnresolvedFlowKirType.toSkieFlowType(): DeclaredKirType {
         val kirClass = flowType.getKotlinKirClass(kirProvider)
 
-        val typeArgument = kirClass.withFlowMappingForTypeArguments {
-            evaluateFlowTypeArgument().substituteFlows()
+        val typeArgument = flowMappingStrategy.run {
+            kirClass.withFlowMappingForTypeArguments {
+                evaluateFlowTypeArgument().substituteFlows()
+            }
         }
 
         return DeclaredKirType(

--- a/SKIE/kotlin-compiler/core/src/main/kotlin/co/touchlab/skie/phases/features/flow/FlowBridgingConfigurationPhase.kt
+++ b/SKIE/kotlin-compiler/core/src/main/kotlin/co/touchlab/skie/phases/features/flow/FlowBridgingConfigurationPhase.kt
@@ -6,17 +6,17 @@ import co.touchlab.skie.phases.SirPhase
 
 object FlowBridgingConfigurationPhase : SirPhase {
 
-    context(SirPhase.Context)
-    override fun isActive(): Boolean = SkieConfigurationFlag.Feature_CoroutinesInterop.isEnabled
+    context(context: SirPhase.Context)
+    override fun isActive(): Boolean = context.run { SkieConfigurationFlag.Feature_CoroutinesInterop.isEnabled }
 
-    context(SirPhase.Context)
+    context(context: SirPhase.Context)
     override suspend fun execute() {
         SupportedFlow.values().forEach {
             configureFlowBridging(it)
         }
     }
 
-    context(SirPhase.Context)
+    context(context: SirPhase.Context)
     private fun configureFlowBridging(supportedFlow: SupportedFlow) {
         supportedFlow.variants.forEach {
             it.getKotlinKirClass().bridgedSirClass = it.getSwiftClass()

--- a/SKIE/kotlin-compiler/core/src/main/kotlin/co/touchlab/skie/phases/features/flow/FlowConversionConstructorsGenerator.kt
+++ b/SKIE/kotlin-compiler/core/src/main/kotlin/co/touchlab/skie/phases/features/flow/FlowConversionConstructorsGenerator.kt
@@ -24,12 +24,12 @@ class FlowConversionConstructorsGenerator(
     private val sirProvider = context.sirProvider
     private val sirBuiltins = context.sirBuiltins
 
-    context(SirPhase.Context)
-    override fun isActive(): Boolean = SkieConfigurationFlag.Feature_CoroutinesInterop.isEnabled
+    context(context: SirPhase.Context)
+    override fun isActive(): Boolean = context.run { SkieConfigurationFlag.Feature_CoroutinesInterop.isEnabled }
 
-    context(SirPhase.Context)
+    context(context: SirPhase.Context)
     override suspend fun execute() {
-        val file = namespaceProvider.getSkieNamespaceFile("FlowConversions")
+        val file = context.namespaceProvider.getSkieNamespaceFile("FlowConversions")
 
         SupportedFlow.values().forEach {
             it.generateAllConversions(file)

--- a/SKIE/kotlin-compiler/core/src/main/kotlin/co/touchlab/skie/phases/features/flow/UnifyFlowConfigurationForOverridesPhase.kt
+++ b/SKIE/kotlin-compiler/core/src/main/kotlin/co/touchlab/skie/phases/features/flow/UnifyFlowConfigurationForOverridesPhase.kt
@@ -15,10 +15,10 @@ class UnifyFlowConfigurationForOverridesPhase(
 
     private val kirProvider = context.kirProvider
 
-    context(KirPhase.Context)
-    override fun isActive(): Boolean = SkieConfigurationFlag.Feature_CoroutinesInterop.isEnabled
+    context(context: KirPhase.Context)
+    override fun isActive(): Boolean = context.run { SkieConfigurationFlag.Feature_CoroutinesInterop.isEnabled }
 
-    context(KirPhase.Context)
+    context(context: KirPhase.Context)
     override suspend fun execute() {
         kirProvider.kotlinOverridableDeclaration
             .filter { it.isBaseDeclaration && it.overriddenBy.isNotEmpty() }

--- a/SKIE/kotlin-compiler/core/src/main/kotlin/co/touchlab/skie/phases/features/functions/FileScopeConvertorPhase.kt
+++ b/SKIE/kotlin-compiler/core/src/main/kotlin/co/touchlab/skie/phases/features/functions/FileScopeConvertorPhase.kt
@@ -17,9 +17,9 @@ class FileScopeConvertorPhase(
     private val globalMembersDelegate = GlobalMembersConvertorDelegate(parentProvider)
     private val interfaceExtensionMembersDelegate = InterfaceExtensionMembersConvertorDelegate(parentProvider)
 
-    context(SirPhase.Context)
+    context(context: SirPhase.Context)
     override suspend fun execute() {
-        kirProvider.kotlinClasses
+        context.kirProvider.kotlinClasses
             .filter { it.kind == KirClass.Kind.File }
             .flatMap { it.callableDeclarations }
             .filter { it.isInteropEnabled }

--- a/SKIE/kotlin-compiler/core/src/main/kotlin/co/touchlab/skie/phases/features/sealed/SealedEnumGeneratorDelegate.kt
+++ b/SKIE/kotlin-compiler/core/src/main/kotlin/co/touchlab/skie/phases/features/sealed/SealedEnumGeneratorDelegate.kt
@@ -25,12 +25,12 @@ class SealedEnumGeneratorDelegate(
     override val context: SirPhase.Context,
 ) : SealedGeneratorExtensionContainer {
 
-    context(SirPhase.Context)
+    context(context: SirPhase.Context)
     fun generate(kirClass: KirClass): SirClass =
         SirClass(
             baseName = "Sealed",
             kind = SirClass.Kind.Enum,
-            parent = namespaceProvider.getNamespaceExtension(kirClass),
+            parent = context.namespaceProvider.getNamespaceExtension(kirClass),
             isReplaced = true,
             isHidden = true,
         ).apply {
@@ -43,10 +43,10 @@ class SealedEnumGeneratorDelegate(
             attributes.add("frozen")
         }
 
-    context(SirPhase.Context)
+    context(context: SirPhase.Context)
     private fun SirClass.addConformanceToHashableIfPossible(kirClass: KirClass) {
         if (kirClass.areAllExposedChildrenHashable && kirClass.areAllSuperTypesValid) {
-            this.superTypes.add(sirBuiltins.Swift.Hashable.defaultType)
+            this.superTypes.add(context.sirBuiltins.Swift.Hashable.defaultType)
         }
     }
 

--- a/SKIE/kotlin-compiler/core/src/main/kotlin/co/touchlab/skie/phases/features/sealed/SealedFunctionGeneratorDelegate.kt
+++ b/SKIE/kotlin-compiler/core/src/main/kotlin/co/touchlab/skie/phases/features/sealed/SealedFunctionGeneratorDelegate.kt
@@ -24,7 +24,7 @@ class SealedFunctionGeneratorDelegate(
     override val context: SirPhase.Context,
 ) : SealedGeneratorExtensionContainer {
 
-    context(SirPhase.Context)
+    context(context: SirPhase.Context)
     fun generate(kirClass: KirClass, enum: SirClass) {
         val requiredFunction = generateRequiredOverload(kirClass, enum)
         generateOptionalOverload(kirClass, enum, requiredFunction)

--- a/SKIE/kotlin-compiler/core/src/main/kotlin/co/touchlab/skie/phases/features/sealed/SealedInteropGenerator.kt
+++ b/SKIE/kotlin-compiler/core/src/main/kotlin/co/touchlab/skie/phases/features/sealed/SealedInteropGenerator.kt
@@ -14,9 +14,9 @@ class SealedInteropGenerator(
     private val sealedEnumGeneratorDelegate = SealedEnumGeneratorDelegate(context)
     private val sealedFunctionGeneratorDelegate = SealedFunctionGeneratorDelegate(context)
 
-    context(SirPhase.Context)
+    context(context: SirPhase.Context)
     override suspend fun execute() {
-        kirProvider.kotlinClasses
+        context.kirProvider.kotlinClasses
             .filter { it.isSupported }
             .forEach {
                 generate(it)
@@ -31,7 +31,7 @@ class SealedInteropGenerator(
     private val KirClass.isSealedInteropEnabled: Boolean
         get() = this.configuration[SealedInterop.Enabled]
 
-    context(SirPhase.Context)
+    context(context: SirPhase.Context)
     private fun generate(kirClass: KirClass) {
         val enum = sealedEnumGeneratorDelegate.generate(kirClass)
 

--- a/SKIE/kotlin-compiler/core/src/main/kotlin/co/touchlab/skie/phases/features/suspend/SkieClassSuspendGenerator.kt
+++ b/SKIE/kotlin-compiler/core/src/main/kotlin/co/touchlab/skie/phases/features/suspend/SkieClassSuspendGenerator.kt
@@ -14,7 +14,7 @@ class SkieClassSuspendGenerator {
 
     private val skieClassCache = mutableMapOf<KirClass, SirClass>()
 
-    context(SirPhase.Context)
+    context(context: SirPhase.Context)
     fun getOrCreateSuspendClass(suspendFunctionOwner: KirClass): SirClass =
         skieClassCache.getOrPut(suspendFunctionOwner) {
             val skieClass = createSkieClass(suspendFunctionOwner)
@@ -24,11 +24,11 @@ class SkieClassSuspendGenerator {
             skieClass
         }
 
-    context(SirPhase.Context)
+    context(context: SirPhase.Context)
     private fun createSkieClass(suspendFunctionOwner: KirClass): SirClass =
         SirClass(
             baseName = "Suspend",
-            parent = namespaceProvider.getNamespaceExtension(suspendFunctionOwner),
+            parent = context.namespaceProvider.getNamespaceExtension(suspendFunctionOwner),
             isReplaced = true,
             isHidden = true,
             kind = SirClass.Kind.Struct,
@@ -38,12 +38,12 @@ class SkieClassSuspendGenerator {
             addSkieClassMembers(suspendFunctionOwner)
         }
 
-    context(SirPhase.Context)
+    context(context: SirPhase.Context)
     private fun generateNamespaceProvider(suspendFunctionOwner: KirClass, skieClass: SirClass) {
         SirSimpleFunction(
             identifier = "skie",
-            parent = namespaceProvider.getNamespaceFile(suspendFunctionOwner),
-            returnType = sirBuiltins.Swift.Void.defaultType,
+            parent = context.namespaceProvider.getNamespaceFile(suspendFunctionOwner),
+            returnType = context.sirBuiltins.Swift.Void.defaultType,
         ).apply {
             copyTypeParametersFrom(skieClass)
 
@@ -87,7 +87,7 @@ private fun SirClass.addSkieClassConstructor(suspendFunctionOwner: KirClass) {
         SirValueParameter(
             label = "_",
             name = SkieClassSuspendGenerator.kotlinObjectVariableName,
-            type = suspendFunctionOwner.originalSirClass.toTypeFromEnclosingTypeParameters(this@SirClass.typeParameters),
+            type = suspendFunctionOwner.originalSirClass.toTypeFromEnclosingTypeParameters(this@addSkieClassConstructor.typeParameters),
         )
 
         bodyBuilder.add {

--- a/SKIE/kotlin-compiler/core/src/main/kotlin/co/touchlab/skie/phases/features/suspend/SwiftSuspendFunctionGenerator.kt
+++ b/SKIE/kotlin-compiler/core/src/main/kotlin/co/touchlab/skie/phases/features/suspend/SwiftSuspendFunctionGenerator.kt
@@ -25,7 +25,7 @@ class SwiftSuspendFunctionGenerator {
 
     private val skieClassSuspendGenerator = SkieClassSuspendGenerator()
 
-    context(SirPhase.Context)
+    context(context: SirPhase.Context)
     fun generateSwiftBridgingFunction(
         suspendKirFunction: KirSimpleFunction,
         kotlinBridgingKirFunction: KirSimpleFunction,
@@ -39,9 +39,9 @@ class SwiftSuspendFunctionGenerator {
             return
         }
 
-        val extension = sirProvider.getExtension(
+        val extension = context.sirProvider.getExtension(
             classDeclaration = bridgeModel.extensionTypeDeclarationForBridgingFunction,
-            parent = namespaceProvider.getNamespaceFile(bridgeModel.suspendFunctionOwner),
+            parent = context.namespaceProvider.getNamespaceFile(bridgeModel.suspendFunctionOwner),
         )
 
         bridgeModel.suspendKirFunction.bridgedSirFunction = extension.createSwiftBridgingFunction(bridgeModel)
@@ -49,7 +49,7 @@ class SwiftSuspendFunctionGenerator {
         hideOriginalFunction(bridgeModel)
     }
 
-    context(SirPhase.Context)
+    context(context: SirPhase.Context)
     private fun hideOriginalFunction(bridgeModel: SuspendFunctionBridgeModel) {
         bridgeModel.suspendKirFunctionAssociatedDeclarations.forEach {
             it.applyToEntireOverrideHierarchy {
@@ -60,7 +60,7 @@ class SwiftSuspendFunctionGenerator {
         }
     }
 
-    context(SirPhase.Context)
+    context(context: SirPhase.Context)
     private val SuspendFunctionBridgeModel.extensionTypeDeclarationForBridgingFunction: SirClass
         get() {
             return if (this.isFromGenericClass) {
@@ -71,7 +71,7 @@ class SwiftSuspendFunctionGenerator {
         }
 }
 
-context(SirPhase.Context)
+context(context: SirPhase.Context)
 private fun SirExtension.createSwiftBridgingFunction(bridgeModel: SuspendFunctionBridgeModel): SirSimpleFunction =
     bridgeModel.originalFunction.shallowCopy(
         parent = this,
@@ -86,7 +86,7 @@ private fun SirExtension.createSwiftBridgingFunction(bridgeModel: SuspendFunctio
         addSwiftBridgingFunctionBody(bridgeModel)
     }
 
-context(SirPhase.Context)
+context(context: SirPhase.Context)
 private fun SirType.revertFlowMappingIfNeeded(): SirType {
     when (this) {
         is OirDeclaredSirType -> {

--- a/SKIE/kotlin-compiler/core/src/main/kotlin/co/touchlab/skie/phases/header/GenerateFakeObjCDependenciesPhase.kt
+++ b/SKIE/kotlin-compiler/core/src/main/kotlin/co/touchlab/skie/phases/header/GenerateFakeObjCDependenciesPhase.kt
@@ -8,9 +8,9 @@ import co.touchlab.skie.util.cache.writeTextIfDifferent
 
 object GenerateFakeObjCDependenciesPhase : SirPhase {
 
-    context(SirPhase.Context)
+    context(context: SirPhase.Context)
     override suspend fun execute() {
-        oirProvider.externalClassesAndProtocols
+        context.oirProvider.externalClassesAndProtocols
             .groupBy { it.originalSirClass.module }
             // TODO: Replace with two types of external modules (fake and SDK) and handle available SDK modules properly.
             .filterKeys { it is SirModule.External && !isKnownSdkModule(it.name) }
@@ -20,13 +20,13 @@ object GenerateFakeObjCDependenciesPhase : SirPhase {
             }
     }
 
-    context(SirPhase.Context)
+    context(context: SirPhase.Context)
     private fun generateFakeFramework(module: SirModule.External, classes: List<OirClass>) {
         generateModuleMap(module)
         generateHeader(module, classes)
     }
 
-    context(SirPhase.Context)
+    context(context: SirPhase.Context)
     private fun generateModuleMap(module: SirModule) {
         val moduleMapContent =
             """
@@ -35,10 +35,10 @@ object GenerateFakeObjCDependenciesPhase : SirPhase {
             }
         """.trimIndent()
 
-        skieBuildDirectory.swiftCompiler.fakeObjCFrameworks.moduleMap(module.name).writeTextIfDifferent(moduleMapContent)
+        context.skieBuildDirectory.swiftCompiler.fakeObjCFrameworks.moduleMap(module.name).writeTextIfDifferent(moduleMapContent)
     }
 
-    context(SirPhase.Context)
+    context(context: SirPhase.Context)
     private fun generateHeader(module: SirModule, classes: List<OirClass>) {
         val foundationImport = "#import <Foundation/NSObject.h>"
 
@@ -48,7 +48,7 @@ object GenerateFakeObjCDependenciesPhase : SirPhase {
 
         val headerContent = "$foundationImport\n\n$declarations"
 
-        skieBuildDirectory.swiftCompiler.fakeObjCFrameworks.header(module.name).writeTextIfDifferent(headerContent)
+        context.skieBuildDirectory.swiftCompiler.fakeObjCFrameworks.header(module.name).writeTextIfDifferent(headerContent)
     }
 }
 

--- a/SKIE/kotlin-compiler/core/src/main/kotlin/co/touchlab/skie/phases/header/ImportFakeObjCDependenciesPhase.kt
+++ b/SKIE/kotlin-compiler/core/src/main/kotlin/co/touchlab/skie/phases/header/ImportFakeObjCDependenciesPhase.kt
@@ -27,23 +27,23 @@ import co.touchlab.skie.sir.element.SirModule
  */
 object ImportFakeObjCDependenciesPhase : SirPhase {
 
-    context(SirPhase.Context)
+    context(context: SirPhase.Context)
     override suspend fun execute() {
         // TODO: Make sure this runs for both 'fake' and SDK modules once support for distinction between the two module types is added.
-        val fakeExternalModules = sirProvider.allUsedExternalModules.filter { it.name != "Foundation" }
+        val fakeExternalModules = context.sirProvider.allUsedExternalModules.filter { it.name != "Foundation" }
 
         if (fakeExternalModules.isEmpty()) {
             return
         }
 
-        val originalContent = framework.kotlinHeader.readText()
+        val originalContent = context.framework.kotlinHeader.readText()
 
         importFakeFrameworks(fakeExternalModules, originalContent)
 
         revertHeaderChange(originalContent)
     }
 
-    context(SirPhase.Context)
+    context(context: SirPhase.Context)
     private fun importFakeFrameworks(fakeExternalModules: List<SirModule.External>, originalHeader: String) {
         val fakeImports = fakeExternalModules.joinToString("\n") { module ->
             // TODO: Properly fix this for nested modules as part of work to add distinction between the fake and SDK modules.
@@ -54,13 +54,13 @@ object ImportFakeObjCDependenciesPhase : SirPhase {
 
         val updatedContent = originalHeader + "\n$fakeImports"
 
-        framework.kotlinHeader.writeText(updatedContent)
+        context.framework.kotlinHeader.writeText(updatedContent)
     }
 
-    context(SirPhase.Context)
+    context(context: SirPhase.Context)
     private fun revertHeaderChange(originalHeader: String) {
-        doInPhase(RevertPhase) {
-            framework.kotlinHeader.writeText(originalHeader)
+        context.doInPhase(RevertPhase) {
+            context.framework.kotlinHeader.writeText(originalHeader)
         }
     }
 

--- a/SKIE/kotlin-compiler/core/src/main/kotlin/co/touchlab/skie/phases/header/util/BaseHeaderModificationPhase.kt
+++ b/SKIE/kotlin-compiler/core/src/main/kotlin/co/touchlab/skie/phases/header/util/BaseHeaderModificationPhase.kt
@@ -4,15 +4,15 @@ import co.touchlab.skie.phases.SirPhase
 
 abstract class BaseHeaderModificationPhase : SirPhase {
 
-    context(SirPhase.Context)
+    context(context: SirPhase.Context)
     final override suspend fun execute() {
-        val content = framework.kotlinHeader.readLines()
+        val content = context.framework.kotlinHeader.readLines()
 
         val modifiedContent = modifyHeaderContent(content)
 
         val mergedContent = modifiedContent.dropLastWhile { it.isBlank() }.joinToString("\n", postfix = "\n")
 
-        framework.kotlinHeader.writeText(mergedContent)
+        context.framework.kotlinHeader.writeText(mergedContent)
     }
 
     protected abstract fun modifyHeaderContent(content: List<String>): List<String>

--- a/SKIE/kotlin-compiler/core/src/main/kotlin/co/touchlab/skie/phases/kir/InitializeKirMembersCachePhase.kt
+++ b/SKIE/kotlin-compiler/core/src/main/kotlin/co/touchlab/skie/phases/kir/InitializeKirMembersCachePhase.kt
@@ -4,8 +4,8 @@ import co.touchlab.skie.phases.KirPhase
 
 object InitializeKirMembersCachePhase : KirPhase {
 
-    context(KirPhase.Context)
+    context(context: KirPhase.Context)
     override suspend fun execute() {
-        kirProvider.initializeCallableDeclarationsCache()
+        context.kirProvider.initializeCallableDeclarationsCache()
     }
 }

--- a/SKIE/kotlin-compiler/core/src/main/kotlin/co/touchlab/skie/phases/memberconflicts/RenameCallableDeclarationsConflictingWithTypeDeclarationsPhase.kt
+++ b/SKIE/kotlin-compiler/core/src/main/kotlin/co/touchlab/skie/phases/memberconflicts/RenameCallableDeclarationsConflictingWithTypeDeclarationsPhase.kt
@@ -8,9 +8,9 @@ import co.touchlab.skie.util.resolveCollisionWithWarning
 // TODO This does not work for nested classes
 object RenameCallableDeclarationsConflictingWithTypeDeclarationsPhase : SirPhase {
 
-    context(SirPhase.Context)
+    context(context: SirPhase.Context)
     override suspend fun execute() {
-        val topLevelDeclarations = sirProvider.allSkieGeneratedTopLevelDeclarations
+        val topLevelDeclarations = context.sirProvider.allSkieGeneratedTopLevelDeclarations
 
         val topLevelClasses = topLevelDeclarations.filterIsInstance<SirClass>()
         val reservedNames = topLevelClasses.map { it.simpleName }.toSet()
@@ -22,7 +22,7 @@ object RenameCallableDeclarationsConflictingWithTypeDeclarationsPhase : SirPhase
         }
     }
 
-    context(SirPhase.Context)
+    context(context: SirPhase.Context)
     private fun SirCallableDeclaration.renameIfConflictsWith(reservedNames: Set<String>) {
         this.resolveCollisionWithWarning {
             if (identifierAfterVisibilityChange in reservedNames) "a type name '$identifierAfterVisibilityChange'" else null

--- a/SKIE/kotlin-compiler/core/src/main/kotlin/co/touchlab/skie/phases/memberconflicts/RenameConflictingCallableDeclarationsPhase.kt
+++ b/SKIE/kotlin-compiler/core/src/main/kotlin/co/touchlab/skie/phases/memberconflicts/RenameConflictingCallableDeclarationsPhase.kt
@@ -23,7 +23,7 @@ class RenameConflictingCallableDeclarationsPhase : SirPhase {
     private val highestDistanceToInheritanceHierarchyRootCache = mutableMapOf<SirClass, Int>()
     private val containerFqNameCache = mutableMapOf<SirDeclarationParent, String>()
 
-    context(SirPhase.Context)
+    context(context: SirPhase.Context)
     override suspend fun execute() {
         val sortedEnumCases = getSortedEnumCases()
         val sortedCallableDeclarations = getSortedCallableDeclarations()
@@ -34,15 +34,15 @@ class RenameConflictingCallableDeclarationsPhase : SirPhase {
         uniqueSignatureSet.addCallableDeclarations(sortedCallableDeclarations)
     }
 
-    context(SirPhase.Context)
+    context(context: SirPhase.Context)
     private fun getSortedEnumCases(): List<SirEnumCase> =
-        sirProvider.allLocalEnums.flatMap { it.enumCases }
+        context.sirProvider.allLocalEnums.flatMap { it.enumCases }
 
-    context(SirPhase.Context)
+    context(context: SirPhase.Context)
     private fun getSortedCallableDeclarations(): List<SirCallableDeclaration> {
         val comparator = getCollisionResolutionPriorityComparator()
 
-        return sirProvider.allLocalCallableDeclarations.sortedWith(comparator)
+        return context.sirProvider.allLocalCallableDeclarations.sortedWith(comparator)
     }
 
     /**
@@ -60,13 +60,13 @@ class RenameConflictingCallableDeclarationsPhase : SirPhase {
      * container fqname including file
      * Kotlin signature if available
      */
-    context(SirPhase.Context)
+    context(context: SirPhase.Context)
     private fun getCollisionResolutionPriorityComparator(): Comparator<SirCallableDeclaration> =
         compareByDescending<SirCallableDeclaration> {
             it is SirConstructor && it.valueParameters.isEmpty()
         }
             .thenBy { declaration ->
-                (declaration as? SirProperty)?.let { kirProvider.findEnumEntry(it)?.index } ?: Int.MAX_VALUE
+                (declaration as? SirProperty)?.let { context.kirProvider.findEnumEntry(it)?.index } ?: Int.MAX_VALUE
             }
             .thenBy { it.isRemoved }
             .thenBy {
@@ -109,9 +109,9 @@ class RenameConflictingCallableDeclarationsPhase : SirPhase {
             return 1 + (maxFromSuperTypes ?: 0)
         }
 
-    context(SirPhase.Context)
+    context(context: SirPhase.Context)
     private fun SirCallableDeclaration.getKirDeclarationOrNull(): KirCallableDeclaration<*>? =
-        kirProvider.findCallableDeclaration<SirCallableDeclaration>(this)
+        context.kirProvider.findCallableDeclaration<SirCallableDeclaration>(this)
 
     @Suppress("RecursivePropertyAccessor")
     private val SirDeclarationParent.containerFqName: String
@@ -119,14 +119,14 @@ class RenameConflictingCallableDeclarationsPhase : SirPhase {
             (this.parent?.containerFqName ?: "") + this.toString()
         }
 
-    context(SirPhase.Context)
+    context(context: SirPhase.Context)
     private fun UniqueSignatureSet.addEnumCases(enumCases: List<SirEnumCase>) {
         enumCases.forEach {
             this.add(it)
         }
     }
 
-    context(SirPhase.Context)
+    context(context: SirPhase.Context)
     private fun UniqueSignatureSet.addCallableDeclarations(callableDeclarations: List<SirCallableDeclaration>) {
         callableDeclarations.forEach {
             this.add(it)

--- a/SKIE/kotlin-compiler/core/src/main/kotlin/co/touchlab/skie/phases/memberconflicts/RenameParametersNamedSelfPhase.kt
+++ b/SKIE/kotlin-compiler/core/src/main/kotlin/co/touchlab/skie/phases/memberconflicts/RenameParametersNamedSelfPhase.kt
@@ -6,9 +6,9 @@ import co.touchlab.skie.util.collisionFreeIdentifier
 
 object RenameParametersNamedSelfPhase : SirPhase {
 
-    context(SirPhase.Context)
+    context(context: SirPhase.Context)
     override suspend fun execute() {
-        sirProvider.allSkieGeneratedSimpleFunctions
+        context.sirProvider.allSkieGeneratedSimpleFunctions
             .forEach {
                 renameParametersNamedSelf(it)
             }

--- a/SKIE/kotlin-compiler/core/src/main/kotlin/co/touchlab/skie/phases/memberconflicts/UniqueSignatureSet.kt
+++ b/SKIE/kotlin-compiler/core/src/main/kotlin/co/touchlab/skie/phases/memberconflicts/UniqueSignatureSet.kt
@@ -23,7 +23,7 @@ class UniqueSignatureSet {
 
     private val sirHierarchyCache = SirHierarchyCache()
 
-    context(SirPhase.Context)
+    context(context: SirPhase.Context)
     fun add(callableDeclaration: SirCallableDeclaration) {
         if (callableDeclaration in alreadyAddedDeclarations) {
             return
@@ -46,7 +46,7 @@ class UniqueSignatureSet {
         group.addToCaches()
     }
 
-    context(SirPhase.Context)
+    context(context: SirPhase.Context)
     fun add(enumCase: SirEnumCase) {
         if (enumCase in alreadyAddedEnumCase) {
             return
@@ -82,7 +82,7 @@ class UniqueSignatureSet {
 
         private val callableDeclarations = representative.getEntireOverrideHierarchy()
 
-        context(SirPhase.Context)
+        context(context: SirPhase.Context)
         fun resolveCollisionWithWarning(collisionReasonProvider: SirCallableDeclaration.() -> String?) {
             do {
                 var changed = false

--- a/SKIE/kotlin-compiler/core/src/main/kotlin/co/touchlab/skie/phases/oir/ConfigureExternalOirTypesBridgingPhase.kt
+++ b/SKIE/kotlin-compiler/core/src/main/kotlin/co/touchlab/skie/phases/oir/ConfigureExternalOirTypesBridgingPhase.kt
@@ -15,7 +15,7 @@ class ConfigureExternalOirTypesBridgingPhase(
     private val sirProvider = context.sirProvider
     private val externalApiNotesProvider = context.externalApiNotesProvider
 
-    context(SirPhase.Context)
+    context(context: SirPhase.Context)
     override suspend fun execute() {
         configureBridging()
 
@@ -62,9 +62,9 @@ class ConfigureExternalOirTypesBridgingPhase(
         // TODO We do not know if the type is hashable which is important for type mapping
     }
 
-    context(SirPhase.Context)
+    context(context: SirPhase.Context)
     private fun loadAllPlatformApiNotesIfEnabled() {
-        if (SkieConfigurationFlag.Debug_LoadAllPlatformApiNotes.isEnabled) {
+        if (context.run { SkieConfigurationFlag.Debug_LoadAllPlatformApiNotes.isEnabled }) {
             externalApiNotesProvider.getAllApiNotesEntries()
         }
     }

--- a/SKIE/kotlin-compiler/core/src/main/kotlin/co/touchlab/skie/phases/oir/CreateExternalOirTypesPhase.kt
+++ b/SKIE/kotlin-compiler/core/src/main/kotlin/co/touchlab/skie/phases/oir/CreateExternalOirTypesPhase.kt
@@ -7,20 +7,20 @@ import co.touchlab.skie.phases.SirPhase
 
 object CreateExternalOirTypesPhase : SirPhase {
 
-    context(SirPhase.Context)
+    context(context: SirPhase.Context)
     override suspend fun execute() {
-        kirProvider.allExternalClasses.forEach {
+        context.kirProvider.allExternalClasses.forEach {
             createClass(it)
         }
 
-        oirProvider.initializeExternalClassCache()
+        context.oirProvider.initializeExternalClassCache()
     }
 
-    context(SirPhase.Context)
+    context(context: SirPhase.Context)
     private fun createClass(kirClass: KirClass) {
         val oirClass = OirClass(
             name = kirClass.objCName,
-            parent = oirProvider.externalModule,
+            parent = context.oirProvider.externalModule,
             kind = kirClass.kind.toOirKind(),
             origin = OirClass.Origin.Kir(kirClass),
         )

--- a/SKIE/kotlin-compiler/core/src/main/kotlin/co/touchlab/skie/phases/oir/CreateFakeObjCConstructorsPhase.kt
+++ b/SKIE/kotlin-compiler/core/src/main/kotlin/co/touchlab/skie/phases/oir/CreateFakeObjCConstructorsPhase.kt
@@ -12,9 +12,9 @@ import co.touchlab.skie.sir.element.shallowCopy
 
 object CreateFakeObjCConstructorsPhase : SirPhase {
 
-    context(SirPhase.Context)
+    context(context: SirPhase.Context)
     override suspend fun execute() {
-        oirProvider.kotlinClasses.forEach {
+        context.oirProvider.kotlinClasses.forEach {
             it.addFakeObjCConstructors()
         }
     }

--- a/SKIE/kotlin-compiler/core/src/main/kotlin/co/touchlab/skie/phases/oir/CreateKotlinOirTypesPhase.kt
+++ b/SKIE/kotlin-compiler/core/src/main/kotlin/co/touchlab/skie/phases/oir/CreateKotlinOirTypesPhase.kt
@@ -13,7 +13,7 @@ class CreateKotlinOirTypesPhase(
     private val kirProvider = context.kirProvider
     private val oirProvider = context.oirProvider
 
-    context(SirPhase.Context)
+    context(context: SirPhase.Context)
     override suspend fun execute() {
         createClasses()
 

--- a/SKIE/kotlin-compiler/core/src/main/kotlin/co/touchlab/skie/phases/oir/CreateOirMembersPhase.kt
+++ b/SKIE/kotlin-compiler/core/src/main/kotlin/co/touchlab/skie/phases/oir/CreateOirMembersPhase.kt
@@ -33,7 +33,7 @@ class CreateOirMembersPhase(
 
     private val extensionCache = mutableMapOf<OirClass, OirExtension>()
 
-    context(SirPhase.Context)
+    context(context: SirPhase.Context)
     override suspend fun execute() {
         createAllMembers()
         createAllEnumEntries()

--- a/SKIE/kotlin-compiler/core/src/main/kotlin/co/touchlab/skie/phases/oir/FixOirFunctionSignaturesForApiNotesPhase.kt
+++ b/SKIE/kotlin-compiler/core/src/main/kotlin/co/touchlab/skie/phases/oir/FixOirFunctionSignaturesForApiNotesPhase.kt
@@ -31,9 +31,9 @@ class FixOirFunctionSignaturesForApiNotesPhase(
         context.oirProvider.getFile(context.oirProvider.skieModule, "TypeDefs")
     }
 
-    context(SirPhase.Context)
+    context(context: SirPhase.Context)
     override suspend fun execute() {
-        oirProvider.kotlinClassesAndProtocols.forEach {
+        context.oirProvider.kotlinClassesAndProtocols.forEach {
             fixFunctionSignatures(it)
         }
     }

--- a/SKIE/kotlin-compiler/core/src/main/kotlin/co/touchlab/skie/phases/oir/InitializeOirSuperTypesPhase.kt
+++ b/SKIE/kotlin-compiler/core/src/main/kotlin/co/touchlab/skie/phases/oir/InitializeOirSuperTypesPhase.kt
@@ -5,19 +5,19 @@ import co.touchlab.skie.phases.SirPhase
 
 object InitializeOirSuperTypesPhase : SirPhase {
 
-    context(SirPhase.Context)
+    context(context: SirPhase.Context)
     override suspend fun execute() {
-        kirProvider.allClasses.forEach {
+        context.kirProvider.allClasses.forEach {
             initializeSuperTypes(it)
         }
     }
 
-    context(SirPhase.Context)
+    context(context: SirPhase.Context)
     private fun initializeSuperTypes(kirClass: KirClass) {
         val oirClass = kirClass.oirClass
 
         kirClass.superTypes
-            .map { oirTypeTranslator.mapType(it) }
+            .map { context.oirTypeTranslator.mapType(it) }
             .forEach { superType ->
                 oirClass.superTypes.add(superType)
             }

--- a/SKIE/kotlin-compiler/core/src/main/kotlin/co/touchlab/skie/phases/other/AddAvailabilityBasedDeprecationLevelPhase.kt
+++ b/SKIE/kotlin-compiler/core/src/main/kotlin/co/touchlab/skie/phases/other/AddAvailabilityBasedDeprecationLevelPhase.kt
@@ -10,9 +10,9 @@ import co.touchlab.skie.util.swift.quoteAsSwiftLiteral
 
 object AddAvailabilityBasedDeprecationLevelPhase : SirPhase {
 
-    context(SirPhase.Context)
+    context(context: SirPhase.Context)
     override suspend fun execute() {
-        sirProvider.allSkieGeneratedCallableDeclarations.forEach {
+        context.sirProvider.allSkieGeneratedCallableDeclarations.forEach {
             it.applyDeprecationLevel()
         }
     }

--- a/SKIE/kotlin-compiler/core/src/main/kotlin/co/touchlab/skie/phases/other/AddAvailabilityToAsyncFunctionsPhase.kt
+++ b/SKIE/kotlin-compiler/core/src/main/kotlin/co/touchlab/skie/phases/other/AddAvailabilityToAsyncFunctionsPhase.kt
@@ -4,9 +4,9 @@ import co.touchlab.skie.phases.SirPhase
 
 object AddAvailabilityToAsyncFunctionsPhase : SirPhase {
 
-    context(SirPhase.Context)
+    context(context: SirPhase.Context)
     override suspend fun execute() {
-        sirProvider.allSkieGeneratedSimpleFunctions
+        context.sirProvider.allSkieGeneratedSimpleFunctions
             .filter { it.isAsync }
             .forEach {
                 it.attributes.add("available(iOS 13, macOS 10.15, watchOS 6, tvOS 13, *)")

--- a/SKIE/kotlin-compiler/core/src/main/kotlin/co/touchlab/skie/phases/other/AddFoundationImportsPhase.kt
+++ b/SKIE/kotlin-compiler/core/src/main/kotlin/co/touchlab/skie/phases/other/AddFoundationImportsPhase.kt
@@ -5,9 +5,9 @@ import co.touchlab.skie.sir.element.SirIrFile
 
 object AddFoundationImportsPhase : SirPhase {
 
-    context(SirPhase.Context)
+    context(context: SirPhase.Context)
     override suspend fun execute() {
-        sirProvider.skieModuleFiles
+        context.sirProvider.skieModuleFiles
             .filterIsInstance<SirIrFile>()
             .forEach {
                 it.imports.add("Foundation")

--- a/SKIE/kotlin-compiler/core/src/main/kotlin/co/touchlab/skie/phases/other/AwaitAllBackgroundJobsPhase.kt
+++ b/SKIE/kotlin-compiler/core/src/main/kotlin/co/touchlab/skie/phases/other/AwaitAllBackgroundJobsPhase.kt
@@ -4,8 +4,8 @@ import co.touchlab.skie.phases.LinkPhase
 
 object AwaitAllBackgroundJobsPhase : LinkPhase {
 
-    context(LinkPhase.Context)
+    context(context: LinkPhase.Context)
     override suspend fun execute() {
-        awaitAllBackgroundJobs()
+        context.awaitAllBackgroundJobs()
     }
 }

--- a/SKIE/kotlin-compiler/core/src/main/kotlin/co/touchlab/skie/phases/other/DeleteSkieFrameworkContentPhase.kt
+++ b/SKIE/kotlin-compiler/core/src/main/kotlin/co/touchlab/skie/phases/other/DeleteSkieFrameworkContentPhase.kt
@@ -4,10 +4,10 @@ import co.touchlab.skie.phases.SirPhase
 
 object DeleteSkieFrameworkContentPhase : SirPhase {
 
-    context(SirPhase.Context)
+    context(context: SirPhase.Context)
     override suspend fun execute() {
-        framework.swiftHeader.delete()
-        framework.swiftModuleParent.deleteRecursively()
-        framework.swiftModuleParent.mkdirs()
+        context.framework.swiftHeader.delete()
+        context.framework.swiftModuleParent.deleteRecursively()
+        context.framework.swiftModuleParent.mkdirs()
     }
 }

--- a/SKIE/kotlin-compiler/core/src/main/kotlin/co/touchlab/skie/phases/other/FixDuplicatedOverriddenFunctionsPhase.kt
+++ b/SKIE/kotlin-compiler/core/src/main/kotlin/co/touchlab/skie/phases/other/FixDuplicatedOverriddenFunctionsPhase.kt
@@ -13,9 +13,9 @@ import co.touchlab.skie.sir.element.shallowCopy
 // This fake function is not properly linked with the overrides and as a result this phase needs to run after all other phases that rename functions.
 object FixDuplicatedOverriddenFunctionsPhase : SirPhase {
 
-    context(SirPhase.Context)
+    context(context: SirPhase.Context)
     override suspend fun execute() {
-        oirProvider.kotlinClassesAndProtocols
+        context.oirProvider.kotlinClassesAndProtocols
             .flatMap { it.memberSimpleFunctions }
             .forEach {
                 fixDuplicates(it)

--- a/SKIE/kotlin-compiler/core/src/main/kotlin/co/touchlab/skie/phases/other/GenerateModulemapFilePhase.kt
+++ b/SKIE/kotlin-compiler/core/src/main/kotlin/co/touchlab/skie/phases/other/GenerateModulemapFilePhase.kt
@@ -6,11 +6,11 @@ import co.touchlab.skie.util.GeneratedBySkieComment
 
 sealed class GenerateModulemapFilePhase(private val generateSwiftModule: Boolean) : SirPhase {
 
-    context(SirPhase.Context)
+    context(context: SirPhase.Context)
     override suspend fun execute() {
-        val content = getModulemapContent()
+        val content = context.getModulemapContent()
 
-        framework.modulemapFile.writeText(content)
+        context.framework.modulemapFile.writeText(content)
     }
 
     private fun SirPhase.Context.getModulemapContent(): String =

--- a/SKIE/kotlin-compiler/core/src/main/kotlin/co/touchlab/skie/phases/other/LinkObjectFilesPhase.kt
+++ b/SKIE/kotlin-compiler/core/src/main/kotlin/co/touchlab/skie/phases/other/LinkObjectFilesPhase.kt
@@ -4,10 +4,10 @@ import co.touchlab.skie.phases.LinkPhase
 
 object LinkObjectFilesPhase : LinkPhase {
 
-    context(LinkPhase.Context)
+    context(context: LinkPhase.Context)
     override suspend fun execute() {
-        val additionalObjectFiles = objectFileProvider.allObjectFiles.map { it.absolutePath }
+        val additionalObjectFiles = context.objectFileProvider.allObjectFiles.map { it.absolutePath }
 
-        link(additionalObjectFiles)
+        context.link(additionalObjectFiles)
     }
 }

--- a/SKIE/kotlin-compiler/core/src/main/kotlin/co/touchlab/skie/phases/other/LoadCustomSwiftSourceFilesPhase.kt
+++ b/SKIE/kotlin-compiler/core/src/main/kotlin/co/touchlab/skie/phases/other/LoadCustomSwiftSourceFilesPhase.kt
@@ -4,10 +4,10 @@ import co.touchlab.skie.phases.SirPhase
 
 object LoadCustomSwiftSourceFilesPhase : SirPhase {
 
-    context(SirPhase.Context)
+    context(context: SirPhase.Context)
     override suspend fun execute() {
-        skieBuildDirectory.swift.allNonGeneratedSwiftFiles.forEach {
-            sirFileProvider.loadCompilableFile(it.toPath())
+        context.skieBuildDirectory.swift.allNonGeneratedSwiftFiles.forEach {
+            context.sirFileProvider.loadCompilableFile(it.toPath())
         }
     }
 }

--- a/SKIE/kotlin-compiler/core/src/main/kotlin/co/touchlab/skie/phases/other/VerifyModuleNamePhase.kt
+++ b/SKIE/kotlin-compiler/core/src/main/kotlin/co/touchlab/skie/phases/other/VerifyModuleNamePhase.kt
@@ -67,10 +67,10 @@ object VerifyModuleNamePhase : ClassExportPhase {
         "framework",
     )
 
-    context(ClassExportPhase.Context)
+    context(context: ClassExportPhase.Context)
     override suspend fun execute() {
-        check(framework.frameworkName !in problematicKeywords) {
-            "The name '${framework.frameworkName}' is a reserved keyword in Swift and cannot be used as framework name with SKIE."
+        check(context.framework.frameworkName !in problematicKeywords) {
+            "The name '${context.framework.frameworkName}' is a reserved keyword in Swift and cannot be used as framework name with SKIE."
         }
     }
 }

--- a/SKIE/kotlin-compiler/core/src/main/kotlin/co/touchlab/skie/phases/other/VerifyNoBitcodeEmbeddingPhase.kt
+++ b/SKIE/kotlin-compiler/core/src/main/kotlin/co/touchlab/skie/phases/other/VerifyNoBitcodeEmbeddingPhase.kt
@@ -5,9 +5,9 @@ import co.touchlab.skie.phases.ClassExportPhase
 
 object VerifyNoBitcodeEmbeddingPhase : ClassExportPhase {
 
-    context(ClassExportPhase.Context)
+    context(context: ClassExportPhase.Context)
     override suspend fun execute() {
-        if (swiftCompilerConfiguration.bitcodeEmbeddingMode == SwiftCompilerConfiguration.BitcodeEmbeddingMode.Full) {
+        if (context.swiftCompilerConfiguration.bitcodeEmbeddingMode == SwiftCompilerConfiguration.BitcodeEmbeddingMode.Full) {
             error(
                 "Bitcode embedding is not supported by SKIE. " +
                     "To disable bitcode embedding you likely need to remove `embedBitcode(BitcodeEmbeddingMode.BITCODE)` from the Gradle build script.",

--- a/SKIE/kotlin-compiler/core/src/main/kotlin/co/touchlab/skie/phases/runtime/ConfigureStableNameTypeAliasesForKotlinRuntimePhase.kt
+++ b/SKIE/kotlin-compiler/core/src/main/kotlin/co/touchlab/skie/phases/runtime/ConfigureStableNameTypeAliasesForKotlinRuntimePhase.kt
@@ -8,16 +8,16 @@ import co.touchlab.skie.phases.SirPhase
 
 object ConfigureStableNameTypeAliasesForKotlinRuntimePhase : SirPhase {
 
-    context(SirPhase.Context)
-    override fun isActive(): Boolean = SkieConfigurationFlag.Feature_CoroutinesInterop.isEnabled
+    context(context: SirPhase.Context)
+    override fun isActive(): Boolean = with(context) { SkieConfigurationFlag.Feature_CoroutinesInterop.isEnabled }
 
-    context(SirPhase.Context)
+    context(context: SirPhase.Context)
     override suspend fun execute() {
         SupportedFlow.values().forEach {
             it.getCoroutinesKirClass().enableStableNameTypeAlias()
         }
 
-        kirProvider.getClassByFqName("kotlinx.coroutines.Runnable").enableStableNameTypeAlias()
+        context.kirProvider.getClassByFqName("kotlinx.coroutines.Runnable").enableStableNameTypeAlias()
     }
 
     private fun KirClass.enableStableNameTypeAlias() {

--- a/SKIE/kotlin-compiler/core/src/main/kotlin/co/touchlab/skie/phases/runtime/FlowCombineConversionGenerator.kt
+++ b/SKIE/kotlin-compiler/core/src/main/kotlin/co/touchlab/skie/phases/runtime/FlowCombineConversionGenerator.kt
@@ -4,7 +4,7 @@ import co.touchlab.skie.phases.SirPhase
 
 object FlowCombineConversionGenerator {
 
-    context(SirPhase.Context)
+    context(context: SirPhase.Context)
     fun generate() {
         generateSkieCombineSubscription()
 
@@ -15,9 +15,9 @@ object FlowCombineConversionGenerator {
         generatePublisherSinkExtension()
     }
 
-    context(SirPhase.Context)
+    context(context: SirPhase.Context)
     private fun generateSkieCombineSubscription() {
-        namespaceProvider.getSkieNamespaceWrittenSourceFile("SkieCombineSubscription").content = """
+        context.namespaceProvider.getSkieNamespaceWrittenSourceFile("SkieCombineSubscription").content = """
                 import Combine
 
                 internal final actor SkieCombineSubscription<F: SkieSwiftFlowProtocol<S.Input>, S: Combine.Subscriber>: Combine.Subscription where S.Failure == _Concurrency.CancellationError {
@@ -121,9 +121,9 @@ object FlowCombineConversionGenerator {
             """.trimIndent()
     }
 
-    context(SirPhase.Context)
+    context(context: SirPhase.Context)
     private fun generateSkieFlowPublisher() {
-        namespaceProvider.getSkieNamespaceWrittenSourceFile("SkieFlowPublisher").content = """
+        context.namespaceProvider.getSkieNamespaceWrittenSourceFile("SkieFlowPublisher").content = """
                 import Combine
 
                 internal struct SkieFlowPublisher<Output, F: SkieSwiftFlowProtocol<Output>>: Combine.Publisher {
@@ -141,9 +141,9 @@ object FlowCombineConversionGenerator {
             """.trimIndent()
     }
 
-    context(SirPhase.Context)
+    context(context: SirPhase.Context)
     private fun generateToPublisherExtension() {
-        namespaceProvider.getSkieNamespaceWrittenSourceFile("SkieSwiftFlowProtocol+toPublisher").content = """
+        context.namespaceProvider.getSkieNamespaceWrittenSourceFile("SkieSwiftFlowProtocol+toPublisher").content = """
                 import Combine
 
                 extension SkieSwiftFlowProtocol {
@@ -159,9 +159,9 @@ object FlowCombineConversionGenerator {
             """.trimIndent()
     }
 
-    context(SirPhase.Context)
+    context(context: SirPhase.Context)
     private fun generatePublisherSinkExtension() {
-        namespaceProvider.getSkieNamespaceWrittenSourceFile("Combine.Publisher+sink").content = """
+        context.namespaceProvider.getSkieNamespaceWrittenSourceFile("Combine.Publisher+sink").content = """
             import Combine
 
             extension Combine.Publisher where Self.Failure == _Concurrency.CancellationError {

--- a/SKIE/kotlin-compiler/core/src/main/kotlin/co/touchlab/skie/phases/runtime/FutureCombineExtensionGenerator.kt
+++ b/SKIE/kotlin-compiler/core/src/main/kotlin/co/touchlab/skie/phases/runtime/FutureCombineExtensionGenerator.kt
@@ -4,9 +4,9 @@ import co.touchlab.skie.phases.SirPhase
 
 object FutureCombineExtensionGenerator {
 
-    context(SirPhase.Context)
+    context(context: SirPhase.Context)
     fun generate() {
-        namespaceProvider.getSkieNamespaceWrittenSourceFile("Combine.Future+asyncInit").content = """
+        context.namespaceProvider.getSkieNamespaceWrittenSourceFile("Combine.Future+asyncInit").content = """
             import Combine
 
             extension Combine.Future where Failure == Swift.Error {

--- a/SKIE/kotlin-compiler/core/src/main/kotlin/co/touchlab/skie/phases/runtime/KotlinRuntimeHidingPhase.kt
+++ b/SKIE/kotlin-compiler/core/src/main/kotlin/co/touchlab/skie/phases/runtime/KotlinRuntimeHidingPhase.kt
@@ -6,12 +6,12 @@ import co.touchlab.skie.phases.SirPhase
 
 object KotlinRuntimeHidingPhase : SirPhase {
 
-    context(SirPhase.Context)
-    override fun isActive(): Boolean = SkieConfigurationFlag.Feature_CoroutinesInterop.isEnabled
+    context(context: SirPhase.Context)
+    override fun isActive(): Boolean = context.run { SkieConfigurationFlag.Feature_CoroutinesInterop.isEnabled }
 
-    context(SirPhase.Context)
+    context(context: SirPhase.Context)
     override suspend fun execute() {
-        kirProvider.kotlinClasses
+        context.kirProvider.kotlinClasses
             .filter { it.module.origin == KirModule.Origin.SkieRuntime }
             .forEach {
                 it.originalSirClass.isHidden = true

--- a/SKIE/kotlin-compiler/core/src/main/kotlin/co/touchlab/skie/phases/runtime/SkieSwiftFlowIteratorGenerator.kt
+++ b/SKIE/kotlin-compiler/core/src/main/kotlin/co/touchlab/skie/phases/runtime/SkieSwiftFlowIteratorGenerator.kt
@@ -14,13 +14,13 @@ import co.touchlab.skie.sir.element.toTypeParameterUsage
 
 object SkieSwiftFlowIteratorGenerator {
 
-    context(SirPhase.Context)
+    context(context: SirPhase.Context)
     fun generate(): SirClass {
-        return namespaceProvider.getSkieNamespaceFile("SkieSwiftFlowIterator").run {
+        return context.namespaceProvider.getSkieNamespaceFile("SkieSwiftFlowIterator").run {
             SirClass(
                 baseName = "SkieSwiftFlowIterator",
                 superTypes = listOf(
-                    sirBuiltins._Concurrency.AsyncIteratorProtocol.defaultType,
+                    context.sirBuiltins._Concurrency.AsyncIteratorProtocol.defaultType,
                 ),
             ).apply {
                 val tParameter = SirTypeParameter("T")
@@ -37,20 +37,20 @@ object SkieSwiftFlowIteratorGenerator {
         }
     }
 
-    context(SirPhase.Context)
+    context(context: SirPhase.Context)
     private fun SirClass.addIteratorProperty() {
-        val skieColdFlowIterator = kirProvider
+        val skieColdFlowIterator = context.kirProvider
             .getClassByFqName("co.touchlab.skie.runtime.coroutines.flow.SkieColdFlowIterator")
             .originalSirClass
 
         SirProperty(
             identifier = "iterator",
-            type = skieColdFlowIterator.toType(sirBuiltins.Swift.AnyObject.defaultType),
+            type = skieColdFlowIterator.toType(context.sirBuiltins.Swift.AnyObject.defaultType),
             visibility = SirVisibility.Private,
         )
     }
 
-    context(SirPhase.Context)
+    context(context: SirPhase.Context)
     private fun SirClass.addInternalConstructor() {
         SirConstructor(
             visibility = SirVisibility.Internal,
@@ -66,11 +66,11 @@ object SkieSwiftFlowIteratorGenerator {
         }
     }
 
-    context(SirPhase.Context)
+    context(context: SirPhase.Context)
     private fun SirClass.addNextFunction(elementAlias: SirTypeAlias) {
         SirSimpleFunction(
             identifier = "next",
-            returnType = sirBuiltins.Swift.Optional.toType(elementAlias.type),
+            returnType = context.sirBuiltins.Swift.Optional.toType(elementAlias.type),
             isAsync = true,
         ).apply {
             bodyBuilder.add {
@@ -97,11 +97,11 @@ object SkieSwiftFlowIteratorGenerator {
         }
     }
 
-    context(SirPhase.Context)
+    context(context: SirPhase.Context)
     private fun SirClass.addCancelTaskFunction() {
         SirSimpleFunction(
             identifier = "cancelTask",
-            returnType = sirBuiltins.Swift.Void.defaultType,
+            returnType = context.sirBuiltins.Swift.Void.defaultType,
             visibility = SirVisibility.Private,
             isAsync = true,
         ).apply {

--- a/SKIE/kotlin-compiler/core/src/main/kotlin/co/touchlab/skie/phases/runtime/SupportedFlowRuntimeGenerator.kt
+++ b/SKIE/kotlin-compiler/core/src/main/kotlin/co/touchlab/skie/phases/runtime/SupportedFlowRuntimeGenerator.kt
@@ -30,7 +30,7 @@ import io.outfoxx.swiftpoet.CodeBlock
 
 object SupportedFlowRuntimeGenerator {
 
-    context(SirPhase.Context)
+    context(context: SirPhase.Context)
     fun generate(skieSwiftFlowIterator: SirClass) {
         val skieSwiftFlowProtocol = generateSkieSwiftFlowProtocol(skieSwiftFlowIterator)
 
@@ -46,13 +46,13 @@ object SupportedFlowRuntimeGenerator {
         generateBridgeSubscriptionCountWorkaroundFunctions()
     }
 
-    context(SirPhase.Context)
+    context(context: SirPhase.Context)
     private fun generateSkieSwiftFlowProtocol(skieSwiftFlowIterator: SirClass): SkieSwiftFlowProtocol {
-        namespaceProvider.getSkieNamespaceFile("SkieSwiftFlowProtocol").apply {
+        context.namespaceProvider.getSkieNamespaceFile("SkieSwiftFlowProtocol").apply {
             val skieSwiftFlowProtocol = SirClass(
                 baseName = "SkieSwiftFlowProtocol",
                 kind = SirClass.Kind.Protocol,
-                superTypes = listOf(sirBuiltins._Concurrency.AsyncSequence.defaultType),
+                superTypes = listOf(context.sirBuiltins._Concurrency.AsyncSequence.defaultType),
             ).run {
                 val elementTypeParameter = SirTypeParameter(
                     name = "Element",
@@ -60,7 +60,7 @@ object SupportedFlowRuntimeGenerator {
                 )
 
                 SirConditionalConstraint(
-                    sirBuiltins._Concurrency.AsyncSequence.getTypeParameter("AsyncIterator"),
+                    context.sirBuiltins._Concurrency.AsyncSequence.getTypeParameter("AsyncIterator"),
                     bounds = listOf(
                         skieSwiftFlowIterator.toType(
                             elementTypeParameter.toTypeParameterUsage(),
@@ -71,7 +71,7 @@ object SupportedFlowRuntimeGenerator {
                 val delegateTypeParameter = SirTypeParameter(
                     name = "Delegate",
                     bounds = listOf(
-                        kirProvider.getClassByFqName("kotlinx.coroutines.flow.Flow").primarySirClass.defaultType.toConformanceBound(),
+                        context.kirProvider.getClassByFqName("kotlinx.coroutines.flow.Flow").primarySirClass.defaultType.toConformanceBound(),
                     ),
                 )
 
@@ -111,14 +111,14 @@ object SupportedFlowRuntimeGenerator {
         }
     }
 
-    context(SirPhase.Context)
+    context(context: SirPhase.Context)
     private fun generateBridgeSubscriptionCountWorkaroundFunctions() {
         // If Flow-interop is disabled globally (or even just for `kotlinx.coroutines.core`),
         // `subscriptionCount` property falls back to Kotlin's `StateFlow` protocol.
         // These two functions make sure our Flow runtime code still compiles as expected.
-        namespaceProvider.getSkieNamespaceFile("bridgeSubscriptionCount").apply {
-            val skieSwiftStateFlowOfInt = sirProvider.getClassByFqName(SirFqName(sirProvider.skieModule, "SkieSwiftStateFlow"))
-                .toType(kirBuiltins.nsNumberDeclarationsByFqName["kotlin.Int"]!!.originalSirClass.defaultType)
+        context.namespaceProvider.getSkieNamespaceFile("bridgeSubscriptionCount").apply {
+            val skieSwiftStateFlowOfInt = context.sirProvider.getClassByFqName(SirFqName(context.sirProvider.skieModule, "SkieSwiftStateFlow"))
+                .toType(context.kirBuiltins.nsNumberDeclarationsByFqName["kotlin.Int"]!!.originalSirClass.defaultType)
 
             SirSimpleFunction(
                 identifier = "bridgeSubscriptionCount",
@@ -144,7 +144,7 @@ object SupportedFlowRuntimeGenerator {
                 SirValueParameter(
                     label = "_",
                     name = "subscriptionCount",
-                    type = kirProvider.getClassByFqName("kotlinx.coroutines.flow.StateFlow").primarySirClass.defaultType.toExistential(),
+                    type = context.kirProvider.getClassByFqName("kotlinx.coroutines.flow.StateFlow").primarySirClass.defaultType.toExistential(),
                 )
 
                 bodyBuilder.add {
@@ -154,24 +154,24 @@ object SupportedFlowRuntimeGenerator {
         }
     }
 
-    context(SirPhase.Context)
+    context(context: SirPhase.Context)
     private fun createSwiftFlowClass(
         flowVariant: SupportedFlow.Variant,
         skieSwiftFlowProtocol: SkieSwiftFlowProtocol,
     ): SirClass {
-        return namespaceProvider.getSkieNamespaceFile(flowVariant.swiftSimpleName).run {
+        return context.namespaceProvider.getSkieNamespaceFile(flowVariant.swiftSimpleName).run {
             SirClass(
                 baseName = flowVariant.swiftSimpleName,
                 superTypes = listOf(
                     skieSwiftFlowProtocol.self.defaultType,
-                    sirBuiltins.Swift._ObjectiveCBridgeable.defaultType,
+                    context.sirBuiltins.Swift._ObjectiveCBridgeable.defaultType,
                 ),
                 modality = SirModality.Final,
             )
         }
     }
 
-    context(SirPhase.Context)
+    context(context: SirPhase.Context)
     private fun SirClass.addSwiftFlowMembers(
         flowVariant: SupportedFlow.Variant,
         skieSwiftFlowIterator: SirClass,
@@ -234,7 +234,7 @@ object SupportedFlowRuntimeGenerator {
         }
     }
 
-    context(SirPhase.Context)
+    context(context: SirPhase.Context)
     private fun SirClass.addPassthroughMembers(
         flowVariant: SupportedFlow.Variant,
         elementTypeAlias: SirTypeAlias,
@@ -246,11 +246,11 @@ object SupportedFlowRuntimeGenerator {
         )
     }
 
-    context(SirPhase.Context)
+    context(context: SirPhase.Context)
     private fun SirClass.addObjCBridgeableImplementation(bridgedClass: SirClass) {
         ObjCBridgeableGenerator.addObjcBridgeableImplementation(
             target = this,
-            bridgedType = bridgedClass.toType(sirBuiltins.Swift.AnyObject.defaultType),
+            bridgedType = bridgedClass.toType(context.sirBuiltins.Swift.AnyObject.defaultType),
             bridgeToObjectiveC = {
                 addStatement("return ${bridgedClass.fqName}(delegate)")
             },
@@ -271,7 +271,7 @@ object SupportedFlowRuntimeGenerator {
         }
     }
 
-    context(SirPhase.Context)
+    context(context: SirPhase.Context)
     private fun SupportedFlow.passthroughDeclarations(elementType: SirType): List<CustomPassthroughDeclaration> {
         val directParents = when (this) {
             SupportedFlow.Flow -> emptyList()
@@ -289,7 +289,7 @@ object SupportedFlowRuntimeGenerator {
             SupportedFlow.SharedFlow -> listOf(
                 CustomPassthroughDeclaration.Property(
                     identifier = "replayCache",
-                    type = sirBuiltins.Swift.Array.toType(elementType),
+                    type = context.sirBuiltins.Swift.Array.toType(elementType),
                     transformGetter = {
                         CodeBlock.of("%L as! [%T]", it, elementType.evaluate().swiftPoetTypeName)
                     },
@@ -298,15 +298,15 @@ object SupportedFlowRuntimeGenerator {
             SupportedFlow.MutableSharedFlow -> listOf(
                 CustomPassthroughDeclaration.Property(
                     identifier = "subscriptionCount",
-                    type = sirProvider.getClassByFqName(SirFqName(sirProvider.skieModule, "SkieSwiftStateFlow"))
-                        .toType(kirBuiltins.nsNumberDeclarationsByFqName["kotlin.Int"]!!.originalSirClass.defaultType),
+                    type = context.sirProvider.getClassByFqName(SirFqName(context.sirProvider.skieModule, "SkieSwiftStateFlow"))
+                        .toType(context.kirBuiltins.nsNumberDeclarationsByFqName["kotlin.Int"]!!.originalSirClass.defaultType),
                     transformGetter = {
                         CodeBlock.of("bridgeSubscriptionCount(%L)", it)
                     },
                 ),
                 CustomPassthroughDeclaration.SimpleFunction(
                     identifier = "emit",
-                    returnType = sirBuiltins.Swift.Void.defaultType,
+                    returnType = context.sirBuiltins.Swift.Void.defaultType,
                     isAsync = true,
                     throws = true,
                     valueParameters = listOf(
@@ -318,7 +318,7 @@ object SupportedFlowRuntimeGenerator {
                 ),
                 CustomPassthroughDeclaration.SimpleFunction(
                     identifier = "tryEmit",
-                    returnType = sirBuiltins.Swift.Bool.defaultType,
+                    returnType = context.sirBuiltins.Swift.Bool.defaultType,
                     valueParameters = listOf(
                         CustomPassthroughDeclaration.SimpleFunction.ValueParameter(
                             name = "value",
@@ -328,7 +328,7 @@ object SupportedFlowRuntimeGenerator {
                 ),
                 CustomPassthroughDeclaration.SimpleFunction(
                     identifier = "resetReplayCache",
-                    returnType = sirBuiltins.Swift.Void.defaultType,
+                    returnType = context.sirBuiltins.Swift.Void.defaultType,
                 ),
             )
             SupportedFlow.StateFlow -> listOf(
@@ -353,7 +353,7 @@ object SupportedFlowRuntimeGenerator {
                 ),
                 CustomPassthroughDeclaration.SimpleFunction(
                     identifier = "compareAndSet",
-                    returnType = sirBuiltins.Swift.Bool.defaultType,
+                    returnType = context.sirBuiltins.Swift.Bool.defaultType,
                     valueParameters = listOf(
                         CustomPassthroughDeclaration.SimpleFunction.ValueParameter(
                             name = "expect",

--- a/SKIE/kotlin-compiler/core/src/main/kotlin/co/touchlab/skie/phases/runtime/SwiftRuntimeGenerator.kt
+++ b/SKIE/kotlin-compiler/core/src/main/kotlin/co/touchlab/skie/phases/runtime/SwiftRuntimeGenerator.kt
@@ -6,29 +6,29 @@ import co.touchlab.skie.util.GeneratedBySkieComment
 
 object SwiftRuntimeGenerator : SirPhase {
 
-    context(SirPhase.Context)
-    override fun isActive(): Boolean = SkieConfigurationFlag.Feature_CoroutinesInterop.isEnabled
+    context(context: SirPhase.Context)
+    override fun isActive(): Boolean = context.run { SkieConfigurationFlag.Feature_CoroutinesInterop.isEnabled }
 
-    context(SirPhase.Context)
+    context(context: SirPhase.Context)
     override suspend fun execute() {
         getSwiftRuntimeFiles().forEach {
             val baseFileContent = it.readText()
 
-            namespaceProvider.getSkieNamespaceWrittenSourceFile(it.swiftFileName).content = "// $GeneratedBySkieComment\n\n$baseFileContent"
+            context.namespaceProvider.getSkieNamespaceWrittenSourceFile(it.swiftFileName).content = "// $GeneratedBySkieComment\n\n$baseFileContent"
         }
 
         val skieSwiftFlowIterator = SkieSwiftFlowIteratorGenerator.generate()
         SupportedFlowRuntimeGenerator.generate(skieSwiftFlowIterator)
 
-        if (SkieConfigurationFlag.Feature_FlowCombineConvertor.isEnabled) {
+        if (context.run { SkieConfigurationFlag.Feature_FlowCombineConvertor.isEnabled }) {
             FlowCombineConversionGenerator.generate()
         }
 
-        if (SkieConfigurationFlag.Feature_FutureCombineExtension.isEnabled) {
+        if (context.run { SkieConfigurationFlag.Feature_FutureCombineExtension.isEnabled }) {
             FutureCombineExtensionGenerator.generate()
         }
 
-        if (SkieConfigurationFlag.Feature_SwiftUIObserving.isEnabled) {
+        if (context.run { SkieConfigurationFlag.Feature_SwiftUIObserving.isEnabled }) {
             SwiftUIFlowObservingGenerator.generate()
         }
     }

--- a/SKIE/kotlin-compiler/core/src/main/kotlin/co/touchlab/skie/phases/runtime/SwiftUIFlowObservingGenerator.kt
+++ b/SKIE/kotlin-compiler/core/src/main/kotlin/co/touchlab/skie/phases/runtime/SwiftUIFlowObservingGenerator.kt
@@ -32,7 +32,7 @@ object SwiftUIFlowObservingGenerator {
     private val availability = "available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)"
     private val maxFlowsOverload = 5
 
-    context(SirPhase.Context)
+    context(context: SirPhase.Context)
     fun generate() {
         generateCollectFlowModifiers()
         val skieSwiftFlowWithInitialValue = generateSkieSwiftFlowWithInitialValue()
@@ -45,18 +45,18 @@ object SwiftUIFlowObservingGenerator {
         generateSkieFlowDoesNotThrow()
     }
 
-    context(SirPhase.Context)
+    context(context: SirPhase.Context)
     private fun generateCollectFlowModifiers() {
-        namespaceProvider.getSkieNamespaceFile("SwiftUI.View+collect").apply {
+        context.namespaceProvider.getSkieNamespaceFile("SwiftUI.View+collect").apply {
             imports += "SwiftUI"
 
             SirExtension(
-                classDeclaration = sirBuiltins.SwiftUI.View,
+                classDeclaration = context.sirBuiltins.SwiftUI.View,
                 attributes = listOf(availability),
             ).apply {
                 SirSimpleFunction(
                     identifier = "collect",
-                    returnType = sirBuiltins.SwiftUI.View.defaultType.toOpaque(),
+                    returnType = context.sirBuiltins.SwiftUI.View.defaultType.toOpaque(),
                 ).apply {
                     documentation = """
                         |A view modifier used to collect a SKIE-bridged Flow into a SwiftUI Binding.
@@ -88,7 +88,7 @@ object SwiftUIFlowObservingGenerator {
                     val flowTypeParameter = SirTypeParameter(
                         name = "Flow",
                         bounds = listOf(
-                            sirBuiltins.Skie.SkieSwiftFlowProtocol.defaultType.toConformanceBound(),
+                            context.sirBuiltins.Skie.SkieSwiftFlowProtocol.defaultType.toConformanceBound(),
                         )
                     )
 
@@ -100,9 +100,9 @@ object SwiftUIFlowObservingGenerator {
                     SirValueParameter(
                         label = "into",
                         name = "binding",
-                        type = sirBuiltins.SwiftUI.Binding.toType(
+                        type = context.sirBuiltins.SwiftUI.Binding.toType(
                             flowTypeParameter.toTypeParameterUsage().typeParameter(
-                                sirBuiltins._Concurrency.AsyncSequence.getTypeParameter("Element"),
+                                context.sirBuiltins._Concurrency.AsyncSequence.getTypeParameter("Element"),
                             )
                         )
                     )
@@ -116,7 +116,7 @@ object SwiftUIFlowObservingGenerator {
 
                 SirSimpleFunction(
                     identifier = "collect",
-                    returnType = sirBuiltins.SwiftUI.View.defaultType.toOpaque(),
+                    returnType = context.sirBuiltins.SwiftUI.View.defaultType.toOpaque(),
                 ).apply {
                     documentation = """
                         |A view modifier used to collect a SKIE-bridged Flow into a SwiftUI Binding, transforming the value before assigning.
@@ -150,7 +150,7 @@ object SwiftUIFlowObservingGenerator {
                     val flowTypeParameter = SirTypeParameter(
                         name = "Flow",
                         bounds = listOf(
-                            sirBuiltins.Skie.SkieSwiftFlowProtocol.defaultType.toConformanceBound(),
+                            context.sirBuiltins.Skie.SkieSwiftFlowProtocol.defaultType.toConformanceBound(),
                         )
                     )
 
@@ -164,7 +164,7 @@ object SwiftUIFlowObservingGenerator {
                     SirValueParameter(
                         label = "into",
                         name = "binding",
-                        type = sirBuiltins.SwiftUI.Binding.toType(
+                        type = context.sirBuiltins.SwiftUI.Binding.toType(
                             uTypeParameter.toTypeParameterUsage()
                         ),
                     )
@@ -174,7 +174,7 @@ object SwiftUIFlowObservingGenerator {
                         type = LambdaSirType(
                             valueParameterTypes = listOf(
                                 flowTypeParameter.toTypeParameterUsage().typeParameter(
-                                    sirBuiltins._Concurrency.AsyncSequence.getTypeParameter("Element"),
+                                    context.sirBuiltins._Concurrency.AsyncSequence.getTypeParameter("Element"),
                                 )
                             ),
                             returnType = uTypeParameter.toTypeParameterUsage().toNullable(),
@@ -194,7 +194,7 @@ object SwiftUIFlowObservingGenerator {
 
                 SirSimpleFunction(
                     identifier = "collect",
-                    returnType = sirBuiltins.SwiftUI.View.defaultType.toOpaque(),
+                    returnType = context.sirBuiltins.SwiftUI.View.defaultType.toOpaque(),
                 ).apply {
                     documentation = """
                         |A view modifier used to collect a SKIE-bridged Flow and perform a closere with each received value.
@@ -230,7 +230,7 @@ object SwiftUIFlowObservingGenerator {
                     val flowTypeParameter = SirTypeParameter(
                         name = "Flow",
                         bounds = listOf(
-                            sirBuiltins.Skie.SkieSwiftFlowProtocol.defaultType.toConformanceBound(),
+                            context.sirBuiltins.Skie.SkieSwiftFlowProtocol.defaultType.toConformanceBound(),
                         )
                     )
 
@@ -244,10 +244,10 @@ object SwiftUIFlowObservingGenerator {
                         type = LambdaSirType(
                             valueParameterTypes = listOf(
                                 flowTypeParameter.toTypeParameterUsage().typeParameter(
-                                    sirBuiltins._Concurrency.AsyncSequence.getTypeParameter("Element"),
+                                    context.sirBuiltins._Concurrency.AsyncSequence.getTypeParameter("Element"),
                                 )
                             ),
-                            returnType = sirBuiltins.Swift.Void.defaultType,
+                            returnType = context.sirBuiltins.Swift.Void.defaultType,
                             isEscaping = true,
                             isAsync = true,
                         )
@@ -268,9 +268,9 @@ object SwiftUIFlowObservingGenerator {
         }
     }
 
-    context(SirPhase.Context)
+    context(context: SirPhase.Context)
     private fun generateSkieSwiftFlowWithInitialValue(): SkieSwiftFlowWithInitialValue {
-        namespaceProvider.getSkieNamespaceFile("SkieSwiftFlowWithInitialValue").apply {
+        context.namespaceProvider.getSkieNamespaceFile("SkieSwiftFlowWithInitialValue").apply {
             val skieSwiftFlowWithInitialValue = SirClass(
                 baseName = "SkieSwiftFlowWithInitialValue",
                 kind = SirClass.Kind.Protocol,
@@ -282,7 +282,7 @@ object SwiftUIFlowObservingGenerator {
                 val flowTypeParameter = SirTypeParameter(
                     name = "Flow",
                     bounds = listOf(
-                        sirBuiltins.Skie.SkieSwiftFlowProtocol.defaultType.toConformanceBound(),
+                        context.sirBuiltins.Skie.SkieSwiftFlowProtocol.defaultType.toConformanceBound(),
                     ),
                     isPrimaryAssociatedType = true,
                 )
@@ -291,7 +291,7 @@ object SwiftUIFlowObservingGenerator {
                     name = "Element",
                     bounds = listOf(
                         flowTypeParameter.toTypeParameterUsage().typeParameter(
-                            sirBuiltins._Concurrency.AsyncSequence.getTypeParameter("Element"),
+                            context.sirBuiltins._Concurrency.AsyncSequence.getTypeParameter("Element"),
                         ).toEqualityBound(),
                     )
                 )
@@ -356,7 +356,7 @@ object SwiftUIFlowObservingGenerator {
                 val flowTypeParameter = SirTypeParameter(
                     name = "Flow",
                     bounds = listOf(
-                        sirBuiltins.Skie.SkieSwiftFlowProtocol.defaultType.toConformanceBound(),
+                        context.sirBuiltins.Skie.SkieSwiftFlowProtocol.defaultType.toConformanceBound(),
                     )
                 )
 
@@ -370,7 +370,7 @@ object SwiftUIFlowObservingGenerator {
                 SirProperty(
                     identifier =  skieSwiftFlowWithInitialValue.initialValueProperty.identifier,
                     type = flowTypeParameter.toTypeParameterUsage().typeParameter(
-                        sirBuiltins._Concurrency.AsyncSequence.getTypeParameter("Element"),
+                        context.sirBuiltins._Concurrency.AsyncSequence.getTypeParameter("Element"),
                     ),
                 ).apply {
                     addOverride(skieSwiftFlowWithInitialValue.initialValueProperty)
@@ -462,9 +462,9 @@ object SwiftUIFlowObservingGenerator {
         }
     }
 
-    context(SirPhase.Context)
+    context(context: SirPhase.Context)
     private fun generateSkieSwiftFlowObserver(): SirClass {
-        return namespaceProvider.getSkieNamespaceFile("SkieSwiftFlowObserver").run {
+        return context.namespaceProvider.getSkieNamespaceFile("SkieSwiftFlowObserver").run {
             imports += "SwiftUI"
 
             SirClass(
@@ -472,13 +472,13 @@ object SwiftUIFlowObservingGenerator {
                 kind = SirClass.Kind.Actor,
                 visibility = SirVisibility.Internal,
                 superTypes = listOf(
-                    sirBuiltins.SwiftUI.ObservableObject.defaultType,
+                    context.sirBuiltins.SwiftUI.ObservableObject.defaultType,
                 )
             ).apply {
                 // TODO: Should be `private(set)`
                 SirProperty(
                     identifier = "values",
-                    type = sirBuiltins.Swift.Array.toType(
+                    type = context.sirBuiltins.Swift.Array.toType(
                         SpecialSirType.Any.toNullable(),
                     ),
                     attributes = listOf(
@@ -490,8 +490,8 @@ object SwiftUIFlowObservingGenerator {
 
                 SirProperty(
                     identifier = "flows",
-                    type = sirBuiltins.Swift.Array.toType(
-                        sirBuiltins.Skie.SkieSwiftFlowProtocol.defaultType.toExistential(),
+                    type = context.sirBuiltins.Swift.Array.toType(
+                        context.sirBuiltins.Skie.SkieSwiftFlowProtocol.defaultType.toExistential(),
                     ),
                     visibility = SirVisibility.Private,
                 )
@@ -501,8 +501,8 @@ object SwiftUIFlowObservingGenerator {
                 ).apply {
                     SirValueParameter(
                         name = "flows",
-                        type = sirBuiltins.Swift.Array.toType(
-                            sirBuiltins.Skie.SkieSwiftFlowProtocol.defaultType.toExistential(),
+                        type = context.sirBuiltins.Swift.Array.toType(
+                            context.sirBuiltins.Skie.SkieSwiftFlowProtocol.defaultType.toExistential(),
                         ),
                     )
 
@@ -514,7 +514,7 @@ object SwiftUIFlowObservingGenerator {
 
                 SirSimpleFunction(
                     identifier = "beginCollecting",
-                    returnType = sirBuiltins.Swift.Void.defaultType,
+                    returnType = context.sirBuiltins.Swift.Void.defaultType,
                     visibility = SirVisibility.Internal,
                     isAsync = true,
                 ).apply {
@@ -537,18 +537,18 @@ object SwiftUIFlowObservingGenerator {
 
                 SirSimpleFunction(
                     identifier = "collect",
-                    returnType = sirBuiltins.Swift.Void.defaultType,
+                    returnType = context.sirBuiltins.Swift.Void.defaultType,
                     visibility = SirVisibility.Private,
                     isAsync = true,
                 ).apply {
                     SirValueParameter(
                         name = "index",
-                        type = sirBuiltins.Swift.Int.defaultType,
+                        type = context.sirBuiltins.Swift.Int.defaultType,
                     )
 
                     SirValueParameter(
                         name = "flow",
-                        type = sirBuiltins.Skie.SkieSwiftFlowProtocol.defaultType.toOpaque(),
+                        type = context.sirBuiltins.Skie.SkieSwiftFlowProtocol.defaultType.toOpaque(),
                     )
 
                     bodyBuilder.add {
@@ -564,7 +564,7 @@ object SwiftUIFlowObservingGenerator {
 
                 SirSimpleFunction(
                     identifier = "set",
-                    returnType = sirBuiltins.Swift.Void.defaultType,
+                    returnType = context.sirBuiltins.Swift.Void.defaultType,
                     visibility = SirVisibility.Private,
                     attributes = listOf(
                         "_Concurrency.MainActor",
@@ -579,7 +579,7 @@ object SwiftUIFlowObservingGenerator {
                     SirValueParameter(
                         label = "for",
                         name = "index",
-                        type = sirBuiltins.Swift.Int.defaultType,
+                        type = context.sirBuiltins.Swift.Int.defaultType,
                     )
 
                     bodyBuilder.add {
@@ -590,9 +590,9 @@ object SwiftUIFlowObservingGenerator {
         }
     }
 
-    context(SirPhase.Context)
+    context(context: SirPhase.Context)
     private fun generateObserveSkieSwiftFlowsView(skieSwiftFlowObserver: SirClass) {
-        namespaceProvider.getSkieNamespaceFile("ObserveSkieSwiftFlows").apply {
+        context.namespaceProvider.getSkieNamespaceFile("ObserveSkieSwiftFlows").apply {
             imports += "SwiftUI"
 
             SirClass(
@@ -600,7 +600,7 @@ object SwiftUIFlowObservingGenerator {
                 kind = SirClass.Kind.Struct,
                 visibility = SirVisibility.Internal,
                 superTypes = listOf(
-                    sirBuiltins.SwiftUI.View.defaultType,
+                    context.sirBuiltins.SwiftUI.View.defaultType,
                 ),
                 attributes = listOf(
                     availability,
@@ -609,13 +609,13 @@ object SwiftUIFlowObservingGenerator {
                 val contentTypeParameter = SirTypeParameter(
                     name = "Content",
                     bounds = listOf(
-                        sirBuiltins.SwiftUI.View.defaultType.toConformanceBound(),
+                        context.sirBuiltins.SwiftUI.View.defaultType.toConformanceBound(),
                     )
                 )
 
                 val contentFactoryType = LambdaSirType(
                     valueParameterTypes = listOf(
-                        sirBuiltins.Swift.Array.toType(
+                        context.sirBuiltins.Swift.Array.toType(
                             SpecialSirType.Any.toNullable(),
                         )
                     ),
@@ -644,8 +644,8 @@ object SwiftUIFlowObservingGenerator {
                 ).apply {
                     SirValueParameter(
                         name = "flows",
-                        type = sirBuiltins.Swift.Array.toType(
-                            sirBuiltins.Skie.SkieSwiftFlowProtocol.defaultType.toExistential(),
+                        type = context.sirBuiltins.Swift.Array.toType(
+                            context.sirBuiltins.Skie.SkieSwiftFlowProtocol.defaultType.toExistential(),
                         )
                     )
 
@@ -668,7 +668,7 @@ object SwiftUIFlowObservingGenerator {
 
                 SirProperty(
                     identifier = "body",
-                    type = sirBuiltins.SwiftUI.View.defaultType.toOpaque(),
+                    type = context.sirBuiltins.SwiftUI.View.defaultType.toOpaque(),
                     visibility = SirVisibility.Internal,
                 ).apply {
                     SirGetter().apply {
@@ -684,9 +684,9 @@ object SwiftUIFlowObservingGenerator {
         }
     }
 
-    context(SirPhase.Context)
+    context(context: SirPhase.Context)
     private fun generateObservingSwiftUIView(): Observing {
-        return namespaceProvider.getSkieNamespaceFile("Observing").run {
+        return context.namespaceProvider.getSkieNamespaceFile("Observing").run {
             imports += "SwiftUI"
 
             SirClass(
@@ -694,7 +694,7 @@ object SwiftUIFlowObservingGenerator {
                 kind = SirClass.Kind.Struct,
                 visibility = SirVisibility.Public,
                 attributes = listOf(availability),
-                superTypes = listOf(sirBuiltins.SwiftUI.View.defaultType),
+                superTypes = listOf(context.sirBuiltins.SwiftUI.View.defaultType),
             ).run {
                 documentation = """
                     |This SwiftUI view allows observing SKIE-bridged flows.
@@ -752,12 +752,12 @@ object SwiftUIFlowObservingGenerator {
 
                 val initialContent = SirTypeParameter(
                     name = "InitialContent",
-                    bounds = listOf(sirBuiltins.SwiftUI.View.defaultType.toConformanceBound()),
+                    bounds = listOf(context.sirBuiltins.SwiftUI.View.defaultType.toConformanceBound()),
                 )
 
                 val content = SirTypeParameter(
                     name = "Content",
-                    bounds = listOf(sirBuiltins.SwiftUI.View.defaultType.toConformanceBound()),
+                    bounds = listOf(context.sirBuiltins.SwiftUI.View.defaultType.toConformanceBound()),
                 )
 
                 val initialContentFactoryType = LambdaSirType(
@@ -773,19 +773,19 @@ object SwiftUIFlowObservingGenerator {
                 )
 
                 val extractValuesType = LambdaSirType(
-                    valueParameterTypes = listOf(sirBuiltins.Swift.Array.toType(SpecialSirType.Any.toNullable())),
+                    valueParameterTypes = listOf(context.sirBuiltins.Swift.Array.toType(SpecialSirType.Any.toNullable())),
                     returnType = values.toTypeParameterUsage().toNullable(),
                     isEscaping = true,
                 )
 
                 SirProperty(
                     identifier = "flows",
-                    type = sirBuiltins.Swift.Array.toType(sirBuiltins.Skie.SkieSwiftFlowProtocol.defaultType.toExistential()),
+                    type = context.sirBuiltins.Swift.Array.toType(context.sirBuiltins.Skie.SkieSwiftFlowProtocol.defaultType.toExistential()),
                 )
 
                 SirProperty(
                     identifier = "flowIds",
-                    type = sirBuiltins.Swift.Array.toType(sirBuiltins.Swift.ObjectIdentifier.defaultType),
+                    type = context.sirBuiltins.Swift.Array.toType(context.sirBuiltins.Swift.ObjectIdentifier.defaultType),
                 )
 
                 SirProperty(
@@ -817,12 +817,12 @@ object SwiftUIFlowObservingGenerator {
 
                     SirValueParameter(
                         name = "flows",
-                        type = sirBuiltins.Swift.Array.toType(sirBuiltins.Skie.SkieSwiftFlowProtocol.defaultType.toExistential()),
+                        type = context.sirBuiltins.Swift.Array.toType(context.sirBuiltins.Skie.SkieSwiftFlowProtocol.defaultType.toExistential()),
                     )
 
                     SirValueParameter(
                         name = "flowIds",
-                        type = sirBuiltins.Swift.Array.toType(sirBuiltins.Swift.ObjectIdentifier.defaultType),
+                        type = context.sirBuiltins.Swift.Array.toType(context.sirBuiltins.Swift.ObjectIdentifier.defaultType),
                     )
 
                     SirValueParameter(
@@ -854,7 +854,7 @@ object SwiftUIFlowObservingGenerator {
 
                     SirProperty(
                         identifier = "body",
-                        type = sirBuiltins.SwiftUI.View.defaultType.toOpaque(),
+                        type = context.sirBuiltins.SwiftUI.View.defaultType.toOpaque(),
                     ).apply {
                         SirGetter().apply {
                             bodyBuilder.add {
@@ -884,10 +884,10 @@ object SwiftUIFlowObservingGenerator {
         }
     }
 
-    context(SirPhase.Context)
+    context(context: SirPhase.Context)
     private fun generateFlowObservingInitializers(observing: Observing) {
-        val asyncSequenceElementTypeParameter = sirBuiltins._Concurrency.AsyncSequence.getTypeParameter("Element")
-        namespaceProvider.getSkieNamespaceFile("Observing+Flow").apply {
+        val asyncSequenceElementTypeParameter = context.sirBuiltins._Concurrency.AsyncSequence.getTypeParameter("Element")
+        context.namespaceProvider.getSkieNamespaceFile("Observing+Flow").apply {
             imports += "SwiftUI"
 
             SirExtension(
@@ -911,7 +911,7 @@ object SwiftUIFlowObservingGenerator {
                             SirTypeParameter(
                                 name = "Flow$it",
                                 bounds = listOf(
-                                    sirBuiltins.Skie.SkieSwiftFlowProtocol.defaultType.toConformanceBound(),
+                                    context.sirBuiltins.Skie.SkieSwiftFlowProtocol.defaultType.toConformanceBound(),
                                 ),
                             )
                         }
@@ -992,11 +992,11 @@ object SwiftUIFlowObservingGenerator {
         }
     }
 
-    context(SirPhase.Context)
+    context(context: SirPhase.Context)
     private fun generateStateFlowObservingInitializers(observing: Observing, skieSwiftFlowWithInitialValue: SkieSwiftFlowWithInitialValue) {
-        val asyncSequenceElementTypeParameter = sirBuiltins._Concurrency.AsyncSequence.getTypeParameter("Element")
+        val asyncSequenceElementTypeParameter = context.sirBuiltins._Concurrency.AsyncSequence.getTypeParameter("Element")
 
-        namespaceProvider.getSkieNamespaceFile("Observing+StateFlow").apply {
+        context.namespaceProvider.getSkieNamespaceFile("Observing+StateFlow").apply {
             imports += "SwiftUI"
 
             SirExtension(
@@ -1008,7 +1008,7 @@ object SwiftUIFlowObservingGenerator {
                 SirConditionalConstraint(
                     typeParameter = observing.initialContentTypeParameter,
                     bounds = listOf(
-                        sirBuiltins.SwiftUI.EmptyView.defaultType.toEqualityBound(),
+                        context.sirBuiltins.SwiftUI.EmptyView.defaultType.toEqualityBound(),
                     )
                 )
 
@@ -1096,9 +1096,9 @@ object SwiftUIFlowObservingGenerator {
         }
     }
 
-    context(SirPhase.Context)
+    context(context: SirPhase.Context)
     private fun generateAssertingSkieSwiftFlowValueUnwrap() {
-        namespaceProvider.getSkieNamespaceFile("assertingSkieSwiftFlowValueUnwrap").apply {
+        context.namespaceProvider.getSkieNamespaceFile("assertingSkieSwiftFlowValueUnwrap").apply {
             val tParameter = SirTypeParameter(
                 name = "T",
                 parent = SirTypeParameterParent.None,
@@ -1132,22 +1132,22 @@ object SwiftUIFlowObservingGenerator {
         }
     }
 
-    context(SirPhase.Context)
+    context(context: SirPhase.Context)
     private fun generateSkieFlowDoesNotThrow() {
-        namespaceProvider.getSkieNamespaceFile("skieFlowDoesNotThrow").apply {
+        context.namespaceProvider.getSkieNamespaceFile("skieFlowDoesNotThrow").apply {
             SirSimpleFunction(
                 identifier = "skieFlowDoesNotThrow",
-                returnType = sirBuiltins.Swift.Never.defaultType,
+                returnType = context.sirBuiltins.Swift.Never.defaultType,
                 visibility = SirVisibility.Internal,
             ).apply {
                 SirValueParameter(
                     name = "error",
-                    type = sirBuiltins.Swift.Error.defaultType,
+                    type = context.sirBuiltins.Swift.Error.defaultType,
                 )
 
                 SirValueParameter(
                     name = "function",
-                    type = sirBuiltins.Swift.StaticString.defaultType,
+                    type = context.sirBuiltins.Swift.StaticString.defaultType,
                     defaultValue = "#function",
                 )
 

--- a/SKIE/kotlin-compiler/core/src/main/kotlin/co/touchlab/skie/phases/sir/CommitSirIsReplacedPropertyPhase.kt
+++ b/SKIE/kotlin-compiler/core/src/main/kotlin/co/touchlab/skie/phases/sir/CommitSirIsReplacedPropertyPhase.kt
@@ -19,9 +19,9 @@ import co.touchlab.skie.sir.element.applyToEntireOverrideHierarchy
  */
 object CommitSirIsReplacedPropertyPhase : SirPhase {
 
-    context(SirPhase.Context)
+    context(context: SirPhase.Context)
     override suspend fun execute() {
-        sirProvider.allLocalDeclarations
+        context.sirProvider.allLocalDeclarations
             .filterIsInstance<SirDeclarationWithVisibility>()
             .filter { it.isReplaced }
             .forEach {

--- a/SKIE/kotlin-compiler/core/src/main/kotlin/co/touchlab/skie/phases/sir/RenameNonAsciiDeclarationPhase.kt
+++ b/SKIE/kotlin-compiler/core/src/main/kotlin/co/touchlab/skie/phases/sir/RenameNonAsciiDeclarationPhase.kt
@@ -10,9 +10,9 @@ object RenameNonAsciiDeclarationPhase: SirPhase {
     private val firstCharAllowedChars: Set<Char> = (('a'..'z') + ('A' .. 'Z') + '_').toSet()
     private val nextCharAllowedChars: Set<Char> = firstCharAllowedChars + ('0' .. '9')
 
-    context(SirPhase.Context)
+    context(context: SirPhase.Context)
     override suspend fun execute() {
-        oirProvider.kotlinClassesAndProtocols
+        context.oirProvider.kotlinClassesAndProtocols
             .filterNot { isValidAsciiIdentifier(it.originalSirClass.baseName) }
             .forEach {
                 it.originalSirClass.baseName = it.name

--- a/SKIE/kotlin-compiler/core/src/main/kotlin/co/touchlab/skie/phases/sir/member/ConfigureInternalVisibilityForWrappedCallableDeclarationsPhase.kt
+++ b/SKIE/kotlin-compiler/core/src/main/kotlin/co/touchlab/skie/phases/sir/member/ConfigureInternalVisibilityForWrappedCallableDeclarationsPhase.kt
@@ -8,17 +8,17 @@ import co.touchlab.skie.sir.element.isAbstract
 
 object ConfigureInternalVisibilityForWrappedCallableDeclarationsPhase : SirPhase {
 
-    context(SirPhase.Context)
+    context(context: SirPhase.Context)
     override suspend fun execute() {
-        sirProvider.allLocalCallableDeclarations
+        context.sirProvider.allLocalCallableDeclarations
             .filter { it.isWrappedBySkie && it.shouldBeInternalIfWrappedBySkie && it.visibility == SirVisibility.Public && !it.isAbstract }
             .forEach {
                 it.visibility = SirVisibility.Internal
             }
     }
 
-    context(SirPhase.Context)
+    context(context: SirPhase.Context)
     private val SirCallableDeclaration.shouldBeInternalIfWrappedBySkie: Boolean
         // TODO Once SirCallableDeclaration origin is added check even for intermediate wrappers and configure those based on the Kir configuration as well.
-        get() = kirProvider.findCallableDeclaration<SirCallableDeclaration>(this)?.configuration?.get(SkieVisibility) == SkieVisibility.Level.InternalIfWrapped
+        get() = context.kirProvider.findCallableDeclaration<SirCallableDeclaration>(this)?.configuration?.get(SkieVisibility) == SkieVisibility.Level.InternalIfWrapped
 }

--- a/SKIE/kotlin-compiler/core/src/main/kotlin/co/touchlab/skie/phases/sir/member/CreateAsyncSirFunctionsPhase.kt
+++ b/SKIE/kotlin-compiler/core/src/main/kotlin/co/touchlab/skie/phases/sir/member/CreateAsyncSirFunctionsPhase.kt
@@ -9,23 +9,23 @@ import co.touchlab.skie.sir.element.shallowCopy
 
 object CreateAsyncSirFunctionsPhase : SirPhase {
 
-    context(SirPhase.Context)
+    context(context: SirPhase.Context)
     override suspend fun execute() {
-        kirProvider.kotlinSimpleFunctions
+        context.kirProvider.kotlinSimpleFunctions
             .filter { it.isSuspend && it.configuration.isSuspendInteropEnabled }
             .forEach {
                 createAsyncFunction(it)
             }
     }
 
-    context(SirPhase.Context)
+    context(context: SirPhase.Context)
     private fun createAsyncFunction(function: KirSimpleFunction) {
         val originalSirFunction = function.originalSirFunction
 
         val suspendCompletionParameter = function.valueParameters.single { it.kind is KirValueParameter.Kind.SuspendCompletion }
 
         function.bridgedSirFunction = originalSirFunction.shallowCopy(
-            returnType = sirTypeTranslator.mapSuspendCompletionType(suspendCompletionParameter.oirValueParameter.type),
+            returnType = context.sirTypeTranslator.mapSuspendCompletionType(suspendCompletionParameter.oirValueParameter.type),
             isAsync = true,
             throws = true,
         ).apply {

--- a/SKIE/kotlin-compiler/core/src/main/kotlin/co/touchlab/skie/phases/sir/member/CreateSirMembersPhase.kt
+++ b/SKIE/kotlin-compiler/core/src/main/kotlin/co/touchlab/skie/phases/sir/member/CreateSirMembersPhase.kt
@@ -34,7 +34,7 @@ class CreateSirMembersPhase(
     private val kirProvider = context.kirProvider
     private val sirTypeTranslator = context.sirTypeTranslator
 
-    context(SirPhase.Context)
+    context(context: SirPhase.Context)
     override suspend fun execute() {
         createAllMembers()
         createAllEnumEntries()

--- a/SKIE/kotlin-compiler/core/src/main/kotlin/co/touchlab/skie/phases/sir/member/InitializeSirMembersCachePhase.kt
+++ b/SKIE/kotlin-compiler/core/src/main/kotlin/co/touchlab/skie/phases/sir/member/InitializeSirMembersCachePhase.kt
@@ -4,8 +4,8 @@ import co.touchlab.skie.phases.SirPhase
 
 object InitializeSirMembersCachePhase : SirPhase {
 
-    context(SirPhase.Context)
+    context(context: SirPhase.Context)
     override suspend fun execute() {
-        kirProvider.initializeSirCallableDeclarationsCache()
+        context.kirProvider.initializeSirCallableDeclarationsCache()
     }
 }

--- a/SKIE/kotlin-compiler/core/src/main/kotlin/co/touchlab/skie/phases/sir/member/InitializeSirOverridesPhase.kt
+++ b/SKIE/kotlin-compiler/core/src/main/kotlin/co/touchlab/skie/phases/sir/member/InitializeSirOverridesPhase.kt
@@ -7,9 +7,9 @@ import co.touchlab.skie.phases.SirPhase
 
 object InitializeSirOverridesPhase : SirPhase {
 
-    context(SirPhase.Context)
+    context(context: SirPhase.Context)
     override suspend fun execute() {
-        kirProvider.kotlinOverridableDeclaration.forEach(::initializeOverrides)
+        context.kirProvider.kotlinOverridableDeclaration.forEach(::initializeOverrides)
     }
 
     private fun initializeOverrides(overridableDeclaration: KirOverridableDeclaration<*, *>) {

--- a/SKIE/kotlin-compiler/core/src/main/kotlin/co/touchlab/skie/phases/sir/member/NormalizeKotlinCSirVisibilityPhase.kt
+++ b/SKIE/kotlin-compiler/core/src/main/kotlin/co/touchlab/skie/phases/sir/member/NormalizeKotlinCSirVisibilityPhase.kt
@@ -10,9 +10,9 @@ import co.touchlab.skie.sir.element.getAllDeclarationsRecursively
  */
 object NormalizeKotlinSirPrivateVisibilityPhase : SirPhase {
 
-    context(SirPhase.Context)
+    context(context: SirPhase.Context)
     override suspend fun execute() {
-        sirProvider.kotlinModule.getAllDeclarationsRecursively()
+        context.sirProvider.kotlinModule.getAllDeclarationsRecursively()
             .filterIsInstance<SirDeclarationWithVisibility>()
             .forEach {
                 normalizeVisibility(it)

--- a/SKIE/kotlin-compiler/core/src/main/kotlin/co/touchlab/skie/phases/sir/member/PropagateSirIsHiddenPropertyInMembersPhase.kt
+++ b/SKIE/kotlin-compiler/core/src/main/kotlin/co/touchlab/skie/phases/sir/member/PropagateSirIsHiddenPropertyInMembersPhase.kt
@@ -7,9 +7,9 @@ import co.touchlab.skie.phases.SirPhase
 
 object PropagateSirIsHiddenPropertyInMembersPhase : SirPhase {
 
-    context(SirPhase.Context)
+    context(context: SirPhase.Context)
     override suspend fun execute() {
-        kirProvider.kotlinOverridableDeclaration
+        context.kirProvider.kotlinOverridableDeclaration
             .filter { it.isBaseDeclaration && it.overriddenBy.isNotEmpty() }
             .forEach {
                 it.propagateIsHidden()

--- a/SKIE/kotlin-compiler/core/src/main/kotlin/co/touchlab/skie/phases/sir/member/PropagateSirVisibilityToMembersPhase.kt
+++ b/SKIE/kotlin-compiler/core/src/main/kotlin/co/touchlab/skie/phases/sir/member/PropagateSirVisibilityToMembersPhase.kt
@@ -10,9 +10,9 @@ import co.touchlab.skie.sir.type.visibilityConstraint
 
 object PropagateSirVisibilityToMembersPhase : SirPhase {
 
-    context(SirPhase.Context)
+    context(context: SirPhase.Context)
     override suspend fun execute() {
-        sirProvider.allLocalCallableDeclarations.forEach {
+        context.sirProvider.allLocalCallableDeclarations.forEach {
             updateVisibility(it)
         }
     }

--- a/SKIE/kotlin-compiler/core/src/main/kotlin/co/touchlab/skie/phases/sir/member/StripKonanCallableDeclarationManglingPhase.kt
+++ b/SKIE/kotlin-compiler/core/src/main/kotlin/co/touchlab/skie/phases/sir/member/StripKonanCallableDeclarationManglingPhase.kt
@@ -10,9 +10,9 @@ import co.touchlab.skie.phases.SirPhase
 
 object StripKonanCallableDeclarationManglingPhase : SirPhase {
 
-    context(SirPhase.Context)
+    context(context: SirPhase.Context)
     override suspend fun execute() {
-        kirProvider.kotlinCallableDeclarations
+        context.kirProvider.kotlinCallableDeclarations
             .filter { it.isSupported }
             .forEach {
                 it.stripMangling()

--- a/SKIE/kotlin-compiler/core/src/main/kotlin/co/touchlab/skie/phases/sir/member/VerifySirVisibilityInAbstractMembersPhase.kt
+++ b/SKIE/kotlin-compiler/core/src/main/kotlin/co/touchlab/skie/phases/sir/member/VerifySirVisibilityInAbstractMembersPhase.kt
@@ -8,9 +8,9 @@ import co.touchlab.skie.sir.element.SirVisibility
 
 object VerifySirVisibilityInAbstractMembersPhase : SirPhase {
 
-    context(SirPhase.Context)
+    context(context: SirPhase.Context)
     override suspend fun execute() {
-        sirProvider.allLocalCallableDeclarations
+        context.sirProvider.allLocalCallableDeclarations
             .filterIsInstance<SirOverridableDeclaration<*>>()
             .filter { it.isAbstract }
             .forEach {
@@ -18,7 +18,7 @@ object VerifySirVisibilityInAbstractMembersPhase : SirPhase {
             }
     }
 
-    context(SirPhase.Context)
+    context(context: SirPhase.Context)
     private fun updateVisibility(sirOverridableDeclaration: SirOverridableDeclaration<*>) {
         val ownerVisibility = sirOverridableDeclaration.memberOwner?.visibility ?: return
 
@@ -26,13 +26,13 @@ object VerifySirVisibilityInAbstractMembersPhase : SirPhase {
             return
         }
 
-        kirReporter.warning(
+        context.kirReporter.warning(
             "Abstract members should have at least the same SkieVisibility as parent otherwise the parent cannot be safely inherited from in Swift.",
             sirOverridableDeclaration.kirCallableDeclarationOrNull,
         )
     }
 
-    context(SirPhase.Context)
+    context(context: SirPhase.Context)
     private val SirCallableDeclaration.kirCallableDeclarationOrNull: KirCallableDeclaration<*>?
-        get() = kirProvider.findCallableDeclaration<SirCallableDeclaration>(this)
+        get() = context.kirProvider.findCallableDeclaration<SirCallableDeclaration>(this)
 }

--- a/SKIE/kotlin-compiler/core/src/main/kotlin/co/touchlab/skie/phases/sir/type/CreateExternalSirTypesPhase.kt
+++ b/SKIE/kotlin-compiler/core/src/main/kotlin/co/touchlab/skie/phases/sir/type/CreateExternalSirTypesPhase.kt
@@ -7,18 +7,18 @@ import co.touchlab.skie.sir.element.toSirKind
 
 object CreateExternalSirTypesPhase : SirPhase {
 
-    context(SirPhase.Context)
+    context(context: SirPhase.Context)
     override suspend fun execute() {
-        oirProvider.externalClassesAndProtocols.forEach {
+        context.oirProvider.externalClassesAndProtocols.forEach {
             createClass(it)
         }
     }
 
-    context(SirPhase.Context)
+    context(context: SirPhase.Context)
     private fun createClass(oirClass: OirClass) {
         val sirClass = SirClass(
             baseName = oirClass.name,
-            parent = sirProvider.getModuleForExternalClass(oirClass).builtInFile,
+            parent = context.sirProvider.getModuleForExternalClass(oirClass).builtInFile,
             kind = oirClass.kind.toSirKind(),
             origin = SirClass.Origin.Oir(oirClass),
         )

--- a/SKIE/kotlin-compiler/core/src/main/kotlin/co/touchlab/skie/phases/sir/type/CreateKotlinSirExtensionsPhase.kt
+++ b/SKIE/kotlin-compiler/core/src/main/kotlin/co/touchlab/skie/phases/sir/type/CreateKotlinSirExtensionsPhase.kt
@@ -6,17 +6,17 @@ import co.touchlab.skie.sir.element.topLevelParent
 
 object CreateKotlinSirExtensionsPhase : SirPhase {
 
-    context(SirPhase.Context)
+    context(context: SirPhase.Context)
     override suspend fun execute() {
-        oirProvider.kotlinExtensions.forEach {
+        context.oirProvider.kotlinExtensions.forEach {
             createExtension(it)
         }
     }
 
-    context(SirPhase.Context)
+    context(context: SirPhase.Context)
     private fun createExtension(oirExtension: OirExtension) {
         val sirClass = oirExtension.classDeclaration.originalSirClass
 
-        oirExtension.sirExtension = sirProvider.getExtension(sirClass, sirClass.topLevelParent)
+        oirExtension.sirExtension = context.sirProvider.getExtension(sirClass, sirClass.topLevelParent)
     }
 }

--- a/SKIE/kotlin-compiler/core/src/main/kotlin/co/touchlab/skie/phases/sir/type/CreateKotlinSirTypesPhase.kt
+++ b/SKIE/kotlin-compiler/core/src/main/kotlin/co/touchlab/skie/phases/sir/type/CreateKotlinSirTypesPhase.kt
@@ -18,20 +18,20 @@ class CreateKotlinSirTypesPhase : SirPhase {
 
     private val kirToSirClasses = mutableMapOf<KirClass, SirClass>()
 
-    context(SirPhase.Context)
+    context(context: SirPhase.Context)
     override suspend fun execute() {
-        kirProvider.kotlinClasses.forEach {
+        context.kirProvider.kotlinClasses.forEach {
             getOrCreateClass(it)
         }
     }
 
-    context(SirPhase.Context)
+    context(context: SirPhase.Context)
     private fun getOrCreateClass(kirClass: KirClass): SirClass =
         kirToSirClasses.getOrPut(kirClass) {
             createClass(kirClass)
         }
 
-    context(SirPhase.Context)
+    context(context: SirPhase.Context)
     private fun createClass(kirClass: KirClass): SirClass {
         val sirClass = SirClass(
             baseName = kirClass.sirFqName.simpleName,
@@ -50,25 +50,25 @@ class CreateKotlinSirTypesPhase : SirPhase {
         return sirClass
     }
 
-    context(SirPhase.Context)
+    context(context: SirPhase.Context)
     private val KirClass.sirFqName: SirFqName
         get() {
             val firstComponent = this.swiftName.substringBefore(".")
             val secondComponent = this.swiftName.substringAfter(".").takeIf { it.isNotBlank() }
 
             val firstName = SirFqName(
-                module = sirProvider.kotlinModule,
+                module = context.sirProvider.kotlinModule,
                 simpleName = firstComponent,
             )
 
             return if (secondComponent != null) firstName.nested(secondComponent) else firstName
         }
 
-    context(SirPhase.Context)
+    context(context: SirPhase.Context)
     private val KirClass.sirParent: SirDeclarationParent
-        get() = sirFqName.parent?.simpleName?.let { findSirParentRecursively(this, it) } ?: sirProvider.kotlinModule.builtInFile
+        get() = sirFqName.parent?.simpleName?.let { findSirParentRecursively(this, it) } ?: context.sirProvider.kotlinModule.builtInFile
 
-    context(SirPhase.Context)
+    context(context: SirPhase.Context)
     private fun findSirParentRecursively(kirClass: KirClass, parentName: String): SirClass? =
         when (val parent = kirClass.parent) {
             is KirClass -> if (parent.swiftName == parentName) getOrCreateClass(parent) else findSirParentRecursively(parent, parentName)
@@ -77,13 +77,13 @@ class CreateKotlinSirTypesPhase : SirPhase {
 
     companion object {
 
-        context(SirPhase.Context)
+        context(context: SirPhase.Context)
         fun createTypeParameters(oirClass: OirClass, sirClass: SirClass) {
             oirClass.typeParameters.forEach { typeParameter ->
                 typeParameter.sirTypeParameter = SirTypeParameter(
                     name = typeParameter.name,
                     parent = sirClass,
-                    bounds = listOf(sirBuiltins.Swift.AnyObject.defaultType.toConformanceBound()),
+                    bounds = listOf(context.sirBuiltins.Swift.AnyObject.defaultType.toConformanceBound()),
                 )
             }
         }

--- a/SKIE/kotlin-compiler/core/src/main/kotlin/co/touchlab/skie/phases/sir/type/CreateStableTypeAliasesPhase.kt
+++ b/SKIE/kotlin-compiler/core/src/main/kotlin/co/touchlab/skie/phases/sir/type/CreateStableTypeAliasesPhase.kt
@@ -9,31 +9,31 @@ import co.touchlab.skie.sir.element.isExported
 
 object CreateStableNameTypeAliasesPhase : SirPhase {
 
-    context(SirPhase.Context)
+    context(context: SirPhase.Context)
     private val shouldGenerateFileForEachExportedClass: Boolean
-        get() = SkieConfigurationFlag.Debug_GenerateFileForEachExportedClass.isEnabled
+        get() = context.run { SkieConfigurationFlag.Debug_GenerateFileForEachExportedClass.isEnabled }
 
-    context(SirPhase.Context)
+    context(context: SirPhase.Context)
     private val useStableTypeAliases: Boolean
-        get() = SkieConfigurationFlag.Debug_UseStableTypeAliases.isEnabled
+        get() = context.run { SkieConfigurationFlag.Debug_UseStableTypeAliases.isEnabled }
 
-    context(SirPhase.Context)
+    context(context: SirPhase.Context)
     override suspend fun execute() {
-        kirProvider.kotlinClasses
+        context.kirProvider.kotlinClasses
             .filter { it.hasStableNameTypeAlias || shouldGenerateFileForEachExportedClass }
             .forEach {
                 createTypeAlias(it)
             }
     }
 
-    context(SirPhase.Context)
+    context(context: SirPhase.Context)
     private fun createTypeAlias(kirClass: KirClass) {
         val typeAlias = SirTypeAlias(
             baseName = "Kotlin",
             parent = if (shouldGenerateFileForEachExportedClass) {
-                namespaceProvider.getNamespaceExtension(kirClass)
+                context.namespaceProvider.getNamespaceExtension(kirClass)
             } else {
-                namespaceProvider.getNamespaceClass(kirClass)
+                context.namespaceProvider.getNamespaceClass(kirClass)
             },
             isReplaced = true,
             isHidden = true,

--- a/SKIE/kotlin-compiler/core/src/main/kotlin/co/touchlab/skie/phases/sir/type/FixNamesOfInaccessibleNestedClassesPhase.kt
+++ b/SKIE/kotlin-compiler/core/src/main/kotlin/co/touchlab/skie/phases/sir/type/FixNamesOfInaccessibleNestedClassesPhase.kt
@@ -8,9 +8,9 @@ import co.touchlab.skie.phases.SirPhase
 // (The nested name is then removed during SirClass instantiation because that uses only the simple name.)
 object FixNamesOfInaccessibleNestedClassesPhase : SirPhase {
 
-    context(SirPhase.Context)
+    context(context: SirPhase.Context)
     override suspend fun execute() {
-        kirProvider.kotlinClasses.forEach(::fixNameOfInaccessibleNestedClass)
+        context.kirProvider.kotlinClasses.forEach(::fixNameOfInaccessibleNestedClass)
     }
 
     private fun fixNameOfInaccessibleNestedClass(kirClass: KirClass) {

--- a/SKIE/kotlin-compiler/core/src/main/kotlin/co/touchlab/skie/phases/sir/type/InitializeSirSuperTypesPhase.kt
+++ b/SKIE/kotlin-compiler/core/src/main/kotlin/co/touchlab/skie/phases/sir/type/InitializeSirSuperTypesPhase.kt
@@ -6,7 +6,7 @@ import co.touchlab.skie.sir.type.SirDeclaredSirType
 
 object InitializeSirSuperTypesPhase : SirPhase {
 
-    context(SirPhase.Context)
+    context(context: SirPhase.Context)
     override suspend fun execute() {
         initializeSuperTypes()
 
@@ -14,16 +14,17 @@ object InitializeSirSuperTypesPhase : SirPhase {
         initializeSuperTypes()
     }
 
-    private fun SirPhase.Context.initializeSuperTypes() {
-        oirProvider.allClassesAndProtocols.forEach {
+    context(context: SirPhase.Context)
+    private fun initializeSuperTypes() {
+        context.oirProvider.allClassesAndProtocols.forEach {
             initializeSuperTypes(it)
         }
     }
 
-    context(SirPhase.Context)
+    context(context: SirPhase.Context)
     private fun initializeSuperTypes(oirClass: OirClass) {
         val sirSuperTypes = oirClass.superTypes
-            .map { sirTypeTranslator.mapType(it) }
+            .map { context.sirTypeTranslator.mapType(it) }
             .map { it.evaluate().type }
             .filterIsInstance<SirDeclaredSirType>()
             .takeIf { it.isNotEmpty() }
@@ -33,10 +34,10 @@ object InitializeSirSuperTypesPhase : SirPhase {
         oirClass.originalSirClass.superTypes.addAll(sirSuperTypes)
     }
 
-    context(SirPhase.Context)
+    context(context: SirPhase.Context)
     private val OirClass.defaultSuperTypes: List<SirDeclaredSirType>
         get() = when (kind) {
-            OirClass.Kind.Class -> listOf(sirBuiltins.Swift.AnyObject.defaultType, sirBuiltins.Swift.Hashable.defaultType)
-            OirClass.Kind.Protocol -> listOf(sirBuiltins.Swift.AnyObject.defaultType)
+            OirClass.Kind.Class -> listOf(context.sirBuiltins.Swift.AnyObject.defaultType, context.sirBuiltins.Swift.Hashable.defaultType)
+            OirClass.Kind.Protocol -> listOf(context.sirBuiltins.Swift.AnyObject.defaultType)
         }
 }

--- a/SKIE/kotlin-compiler/core/src/main/kotlin/co/touchlab/skie/phases/sir/type/PropagateSirVisibilityToClassesPhase.kt
+++ b/SKIE/kotlin-compiler/core/src/main/kotlin/co/touchlab/skie/phases/sir/type/PropagateSirVisibilityToClassesPhase.kt
@@ -12,9 +12,9 @@ import co.touchlab.skie.sir.type.SirType
 
 object PropagateSirVisibilityToClassesPhase : SirPhase {
 
-    context(SirPhase.Context)
+    context(context: SirPhase.Context)
     override suspend fun execute() {
-        val updaterProvider = TypeVisibilityUpdaterProvider(sirProvider.allLocalClasses)
+        val updaterProvider = TypeVisibilityUpdaterProvider(context.sirProvider.allLocalClasses)
 
         updaterProvider.allTypeVisibilityUpdaters.forEach {
             it.propagateVisibility()

--- a/SKIE/kotlin-compiler/core/src/main/kotlin/co/touchlab/skie/phases/sir/type/PropagateSirVisibilityToFileClassesPhase.kt
+++ b/SKIE/kotlin-compiler/core/src/main/kotlin/co/touchlab/skie/phases/sir/type/PropagateSirVisibilityToFileClassesPhase.kt
@@ -10,9 +10,9 @@ import co.touchlab.skie.sir.element.maximumVisibility
 
 object PropagateSirVisibilityToFileClassesPhase : SirPhase {
 
-    context(SirPhase.Context)
+    context(context: SirPhase.Context)
     override suspend fun execute() {
-        sirProvider.allLocalClasses
+        context.sirProvider.allLocalClasses
             .filter { it.kirClassOrNull?.kind == KirClass.Kind.File }
             .forEach {
                 propagateVisibilityFromMembers(it)

--- a/SKIE/kotlin-compiler/core/src/main/kotlin/co/touchlab/skie/phases/sir/type/PropagateSirVisibilityToTypeAliasesPhase.kt
+++ b/SKIE/kotlin-compiler/core/src/main/kotlin/co/touchlab/skie/phases/sir/type/PropagateSirVisibilityToTypeAliasesPhase.kt
@@ -7,9 +7,9 @@ import co.touchlab.skie.sir.type.visibilityConstraint
 
 object PropagateSirVisibilityToTypeAliasesPhase : SirPhase {
 
-    context(SirPhase.Context)
+    context(context: SirPhase.Context)
     override suspend fun execute() {
-        sirProvider.allLocalTypeAliases.forEach {
+        context.sirProvider.allLocalTypeAliases.forEach {
             updateVisibility(it)
         }
     }

--- a/SKIE/kotlin-compiler/core/src/main/kotlin/co/touchlab/skie/phases/swift/CompileSwiftPhase.kt
+++ b/SKIE/kotlin-compiler/core/src/main/kotlin/co/touchlab/skie/phases/swift/CompileSwiftPhase.kt
@@ -34,7 +34,7 @@ class CompileSwiftPhase(
         SkieConfigurationFlag.Build_NoClangModuleBreadcrumbsInStaticFramework in globalConfiguration.enabledFlags
     private val isRelativeSourcePathsInDebugSymbolsEnabled = SkieConfigurationFlag.Build_RelativeSourcePathsInDebugSymbols in globalConfiguration.enabledFlags
 
-    context(SirPhase.Context)
+    context(context: SirPhase.Context)
     override suspend fun execute() {
         val compilableFiles = sirProvider.compilableFiles
 

--- a/SKIE/kotlin-compiler/core/src/main/kotlin/co/touchlab/skie/phases/swift/ConvertSirIrFilesToSourceFilesPhase.kt
+++ b/SKIE/kotlin-compiler/core/src/main/kotlin/co/touchlab/skie/phases/swift/ConvertSirIrFilesToSourceFilesPhase.kt
@@ -5,18 +5,18 @@ import co.touchlab.skie.sir.element.SirIrFile
 
 object ConvertSirIrFilesToSourceFilesPhase : SirPhase {
 
-    context(SirPhase.Context)
+    context(context: SirPhase.Context)
     override suspend fun execute() {
-        sirProvider.skieModuleFiles
+        context.sirProvider.skieModuleFiles
             .filterIsInstance<SirIrFile>()
             .forEach {
                 convertFile(it)
             }
     }
 
-    context(SirPhase.Context)
+    context(context: SirPhase.Context)
     private fun convertFile(sirIrFile: SirIrFile) {
-        val sourceFile = sirFileProvider.getGeneratedSourceFile(sirIrFile)
+        val sourceFile = context.sirFileProvider.getGeneratedSourceFile(sirIrFile)
 
         sourceFile.content = SirCodeGenerator.generate(sirIrFile)
     }

--- a/SKIE/kotlin-compiler/core/src/main/kotlin/co/touchlab/skie/phases/swift/ConvertSirSourceFilesToCompilableFilesPhase.kt
+++ b/SKIE/kotlin-compiler/core/src/main/kotlin/co/touchlab/skie/phases/swift/ConvertSirSourceFilesToCompilableFilesPhase.kt
@@ -8,12 +8,12 @@ import java.io.File
 
 object ConvertSirSourceFilesToCompilableFilesPhase : SirPhase {
 
-    context(SirPhase.Context)
+    context(context: SirPhase.Context)
     override suspend fun execute() {
-        val cacheAwareFileGenerator = CacheAwareFileGenerator(skieBuildDirectory.swift.generated)
+        val cacheAwareFileGenerator = CacheAwareFileGenerator(context.skieBuildDirectory.swift.generated)
 
         with(cacheAwareFileGenerator) {
-            sirProvider.skieModuleFiles
+            context.sirProvider.skieModuleFiles
                 .filterIsInstance<SirSourceFile>()
                 .forEach {
                     it.convertToCompilableFile()
@@ -29,9 +29,9 @@ object ConvertSirSourceFilesToCompilableFilesPhase : SirPhase {
 
         private val generatedFiles = mutableSetOf<File>()
 
-        context(SirPhase.Context)
+        context(context: SirPhase.Context)
         fun SirSourceFile.convertToCompilableFile() {
-            val compilableFile = sirFileProvider.createCompilableFile(this)
+            val compilableFile = context.sirFileProvider.createCompilableFile(this)
 
             generatedFiles.add(compilableFile.absolutePath.toFile())
         }

--- a/SKIE/kotlin-compiler/core/src/main/kotlin/co/touchlab/skie/phases/swift/CopySwiftOutputFilesToFrameworkPhase.kt
+++ b/SKIE/kotlin-compiler/core/src/main/kotlin/co/touchlab/skie/phases/swift/CopySwiftOutputFilesToFrameworkPhase.kt
@@ -11,9 +11,9 @@ class CopySwiftOutputFilesToFrameworkPhase(
     private val swiftFrameworkHeader = context.skieBuildDirectory.swiftCompiler.moduleHeader(framework.frameworkName)
     private val targetTriple = context.swiftCompilerConfiguration.targetTriple
 
-    context(SirPhase.Context)
+    context(context: SirPhase.Context)
     override suspend fun execute() {
-        if (sirProvider.compilableFiles.isNotEmpty()) {
+        if (context.sirProvider.compilableFiles.isNotEmpty()) {
             copySwiftModuleFiles()
             copySwiftLibraryEvolutionFiles()
         } else {
@@ -41,9 +41,9 @@ class CopySwiftOutputFilesToFrameworkPhase(
         framework.swiftHeader.delete()
     }
 
-    context(SirPhase.Context)
+    context(context: SirPhase.Context)
     private fun copySwiftLibraryEvolutionFiles() {
-        if (SkieConfigurationFlag.Build_SwiftLibraryEvolution.isEnabled) {
+        if (with(context) { SkieConfigurationFlag.Build_SwiftLibraryEvolution.isEnabled }) {
             swiftFrameworkHeader.swiftInterface.copyTo(framework.swiftInterface(targetTriple), overwrite = true)
             swiftFrameworkHeader.privateSwiftInterface.copyTo(framework.privateSwiftInterface(targetTriple), overwrite = true)
         } else {

--- a/SKIE/kotlin-compiler/core/src/main/kotlin/co/touchlab/skie/phases/swift/DeleteOldObjectFilesPhase.kt
+++ b/SKIE/kotlin-compiler/core/src/main/kotlin/co/touchlab/skie/phases/swift/DeleteOldObjectFilesPhase.kt
@@ -5,11 +5,11 @@ import kotlin.io.path.nameWithoutExtension
 
 object DeleteOldObjectFilesPhase : SirPhase {
 
-    context(SirPhase.Context)
+    context(context: SirPhase.Context)
     override suspend fun execute() {
-        val objectFileNames = objectFileProvider.allObjectFiles.map { it.absolutePath.nameWithoutExtension }.toSet()
+        val objectFileNames = context.objectFileProvider.allObjectFiles.map { it.absolutePath.nameWithoutExtension }.toSet()
 
-        skieBuildDirectory.swiftCompiler.objectFiles.allFiles
+        context.skieBuildDirectory.swiftCompiler.objectFiles.allFiles
             .filterNot { it.nameWithoutExtension in objectFileNames }
             .forEach {
                 it.delete()

--- a/SKIE/kotlin-compiler/core/src/main/kotlin/co/touchlab/skie/phases/swift/SirCodeGenerator.kt
+++ b/SKIE/kotlin-compiler/core/src/main/kotlin/co/touchlab/skie/phases/swift/SirCodeGenerator.kt
@@ -65,7 +65,7 @@ object SirCodeGenerator {
         return fileBuilder.build().toString()
     }
 
-    context(SirIrFile)
+    context(sirIrFile: SirIrFile)
     private fun FileSpec.Builder.generateCode() {
         generateGeneratedComment()
 
@@ -78,16 +78,16 @@ object SirCodeGenerator {
         addComment(GeneratedBySkieComment)
     }
 
-    context(SirIrFile)
+    context(sirIrFile: SirIrFile)
     private fun FileSpec.Builder.generateImports() {
-        imports.forEach {
+        sirIrFile.imports.forEach {
             addImport(it)
         }
     }
 
-    context(SirIrFile)
+    context(sirIrFile: SirIrFile)
     private fun FileSpec.Builder.generateDeclarations() {
-        declarations.forEach {
+        sirIrFile.declarations.forEach {
             generateDeclaration(it)
         }
     }

--- a/SKIE/kotlin-compiler/core/src/main/kotlin/co/touchlab/skie/phases/swift/SwiftKotlinFrameworkCacheSetupPhase.kt
+++ b/SKIE/kotlin-compiler/core/src/main/kotlin/co/touchlab/skie/phases/swift/SwiftKotlinFrameworkCacheSetupPhase.kt
@@ -6,7 +6,7 @@ import co.touchlab.skie.util.directory.FrameworkLayout
 
 object SwiftKotlinFrameworkCacheSetupPhase : SirPhase {
 
-    context(SirPhase.Context)
+    context(context: SirPhase.Context)
     override suspend fun execute() {
         val wasChanged = synchronizeDummyKotlinFramework()
 
@@ -15,24 +15,24 @@ object SwiftKotlinFrameworkCacheSetupPhase : SirPhase {
         }
     }
 
-    context(SirPhase.Context)
+    context(context: SirPhase.Context)
     private fun synchronizeDummyKotlinFramework(): Boolean {
-        val dummyFramework = cacheableKotlinFramework
+        val dummyFramework = context.cacheableKotlinFramework
 
         // Must use `or` to prevent short circuit optimization.
-        return framework.kotlinHeader.copyFileToIfDifferent(dummyFramework.kotlinHeader) or
-            framework.modulemapFile.copyFileToIfDifferent(dummyFramework.modulemapFile) or
-            skieBuildDirectory.swiftCompiler.apiNotes.apiNotes(framework.frameworkName)
+        return context.framework.kotlinHeader.copyFileToIfDifferent(dummyFramework.kotlinHeader) or
+            context.framework.modulemapFile.copyFileToIfDifferent(dummyFramework.modulemapFile) or
+            context.skieBuildDirectory.swiftCompiler.apiNotes.apiNotes(context.framework.frameworkName)
                 .copyFileToIfDifferent(dummyFramework.apiNotes)
     }
 
     // Solves a bug in Swift compiler.
     // If the module cache is not deleted then all threads rebuild the same cache in series (the caching is done in a synchronized block).
     // This could lead to significant performance degradation if the Obj-C takes a long time to load.
-    context(SirPhase.Context)
+    context(context: SirPhase.Context)
     private fun deleteKotlinFrameworkCache() {
-        skieBuildDirectory.cache.swiftModules.directory.walkTopDown()
-            .filter { it.isFile && it.extension == "pcm" && it.name.startsWith(framework.frameworkName + "-") }
+        context.skieBuildDirectory.cache.swiftModules.directory.walkTopDown()
+            .filter { it.isFile && it.extension == "pcm" && it.name.startsWith(context.framework.frameworkName + "-") }
             .forEach {
                 it.delete()
             }

--- a/SKIE/kotlin-compiler/core/src/main/kotlin/co/touchlab/skie/phases/typeconflicts/RenameTypesConflictingWithKeywordsPhase.kt
+++ b/SKIE/kotlin-compiler/core/src/main/kotlin/co/touchlab/skie/phases/typeconflicts/RenameTypesConflictingWithKeywordsPhase.kt
@@ -11,9 +11,9 @@ object RenameTypesConflictingWithKeywordsPhase : SirPhase {
         "Type",
     )
 
-    context(SirPhase.Context)
+    context(context: SirPhase.Context)
     override suspend fun execute() {
-        sirProvider.allLocalTypeDeclarations
+        context.sirProvider.allLocalTypeDeclarations
             .forEach { declaration ->
                 declaration.resolveCollisionWithWarning {
                     if (declaration.simpleName in problematicKeywords) "a reserved Swift keyword '${declaration.simpleName}'" else null

--- a/SKIE/kotlin-compiler/core/src/main/kotlin/co/touchlab/skie/phases/typeconflicts/RenameTypesConflictingWithKotlinModulePhase.kt
+++ b/SKIE/kotlin-compiler/core/src/main/kotlin/co/touchlab/skie/phases/typeconflicts/RenameTypesConflictingWithKotlinModulePhase.kt
@@ -5,11 +5,11 @@ import co.touchlab.skie.util.resolveCollisionWithWarning
 
 object RenameTypesConflictingWithKotlinModulePhase : SirPhase {
 
-    context(SirPhase.Context)
+    context(context: SirPhase.Context)
     override suspend fun execute() {
-        val moduleName = sirProvider.kotlinModule.name
+        val moduleName = context.sirProvider.kotlinModule.name
 
-        sirProvider.allLocalTypeDeclarations.forEach { type ->
+        context.sirProvider.allLocalTypeDeclarations.forEach { type ->
             type.resolveCollisionWithWarning {
                 if (type.simpleName == moduleName) "the framework name '$moduleName'" else null
             }

--- a/SKIE/kotlin-compiler/core/src/main/kotlin/co/touchlab/skie/phases/typeconflicts/RenameTypesConflictsWithOtherTypesPhase.kt
+++ b/SKIE/kotlin-compiler/core/src/main/kotlin/co/touchlab/skie/phases/typeconflicts/RenameTypesConflictsWithOtherTypesPhase.kt
@@ -14,9 +14,9 @@ import co.touchlab.skie.util.resolveCollisionWithWarning
 
 object RenameTypesConflictsWithOtherTypesPhase : SirPhase {
 
-    context(SirPhase.Context)
+    context(context: SirPhase.Context)
     override suspend fun execute() {
-        val sortedTypeDeclarations = sirProvider.allLocalTypeDeclarations.sortedWith(collisionResolutionPriorityComparator)
+        val sortedTypeDeclarations = context.sirProvider.allLocalTypeDeclarations.sortedWith(collisionResolutionPriorityComparator)
 
         buildUniqueSignatureSet(sortedTypeDeclarations)
     }
@@ -60,7 +60,7 @@ object RenameTypesConflictsWithOtherTypesPhase : SirPhase {
     private fun SirTypeDeclaration.getOirClassOrNull(): OirClass? =
         (this as? SirClass)?.oirClassOrNull
 
-    context(SirPhase.Context)
+    context(context: SirPhase.Context)
     private fun buildUniqueSignatureSet(typeDeclarations: List<SirTypeDeclaration>) {
         val existingFqNames = mutableSetOf<String>()
 

--- a/SKIE/kotlin-compiler/core/src/main/kotlin/co/touchlab/skie/phases/typeconflicts/TemporarilyRenameTypesConflictingWithExternalModulesPhase.kt
+++ b/SKIE/kotlin-compiler/core/src/main/kotlin/co/touchlab/skie/phases/typeconflicts/TemporarilyRenameTypesConflictingWithExternalModulesPhase.kt
@@ -11,18 +11,18 @@ import co.touchlab.skie.sir.element.module
 // Must be the last phase that renames SirTypeDeclarations
 object TemporarilyRenameTypesConflictingWithExternalModulesPhase : SirPhase {
 
-    context(SirPhase.Context)
+    context(context: SirPhase.Context)
     override suspend fun execute() {
-        val conflictingModules = sirProvider.allExternalTypeDeclarations.map { it.module.name }
+        val conflictingModules = context.sirProvider.allExternalTypeDeclarations.map { it.module.name }
         val conflictingNames = conflictingModules.toMutableSet()
 
-        sirProvider.allLocalTypeDeclarations
+        context.sirProvider.allLocalTypeDeclarations
             .forEach {
                 it.renameConflictingType(conflictingNames)
             }
     }
 
-    context(SirPhase.Context)
+    context(context: SirPhase.Context)
     private fun SirTypeDeclaration.renameConflictingType(conflictingNames: MutableSet<String>) {
         registerReverseOperation(this)
 
@@ -33,11 +33,11 @@ object TemporarilyRenameTypesConflictingWithExternalModulesPhase : SirPhase {
         conflictingNames.add(this.fqName.toLocalString())
     }
 
-    context(SirPhase.Context)
+    context(context: SirPhase.Context)
     private fun registerReverseOperation(sirTypeDeclaration: SirTypeDeclaration) {
         val originalBaseName = sirTypeDeclaration.baseName
 
-        doInPhase(RevertPhase) {
+        context.doInPhase(RevertPhase) {
             sirTypeDeclaration.baseName = originalBaseName
         }
     }

--- a/SKIE/kotlin-compiler/core/src/main/kotlin/co/touchlab/skie/phases/util/SkiePhaseGroup.kt
+++ b/SKIE/kotlin-compiler/core/src/main/kotlin/co/touchlab/skie/phases/util/SkiePhaseGroup.kt
@@ -18,15 +18,15 @@ class SkiePhaseGroup<P : ScheduledPhase<C>, C : ScheduledPhase.Context>(
         modifications.add(modification)
     }
 
-    context(C)
+    context(c: C)
     internal suspend fun List<P>.execute(kind: SkiePerformanceAnalytics.Kind) {
         this.forEach {
             if (it.isActive()) {
-                context.skiePerformanceAnalyticsProducer.log(it::class.nameForLogger, kind) {
+                c.skiePerformanceAnalyticsProducer.log(it::class.nameForLogger, kind) {
                     it.execute()
                 }
             } else {
-                context.skiePerformanceAnalyticsProducer.logSkipped(it::class.nameForLogger)
+                c.skiePerformanceAnalyticsProducer.logSkipped(it::class.nameForLogger)
             }
         }
     }
@@ -50,20 +50,20 @@ private val KClass<*>.nameForLogger: String
         ?.takeUnless { it.isBlank() }
         ?: "<Unknown>"
 
-context(ScheduledPhase.Context)
+context(context: ScheduledPhase.Context)
 inline fun <P, reified C : ScheduledPhase.Context> SkiePhaseGroup<P, C>.run(
     noinline contextFactory: () -> C,
 ) where P : ScheduledPhase<C>, P : BackgroundPhase<C> {
     run(C::class, contextFactory)
 }
 
-context(ScheduledPhase.Context)
+context(context: ScheduledPhase.Context)
 fun <P, C : ScheduledPhase.Context> SkiePhaseGroup<P, C>.run(
     contextClass: KClass<C>,
     contextFactory: () -> C,
 ) where P : ScheduledPhase<C>, P : BackgroundPhase<C> {
-    if (SkieConfigurationFlag.Build_ConcurrentSkieCompilation.isEnabled) {
-        this@Context.launch {
+    if (context.run { SkieConfigurationFlag.Build_ConcurrentSkieCompilation.isEnabled }) {
+        context.launch {
             prepareAndExecute(contextClass, contextFactory, SkiePerformanceAnalytics.Kind.Background)
         }
     } else {
@@ -71,26 +71,26 @@ fun <P, C : ScheduledPhase.Context> SkiePhaseGroup<P, C>.run(
     }
 }
 
-context(ScheduledPhase.Context)
+context(context: ScheduledPhase.Context)
 inline fun <P, reified C : ScheduledPhase.Context> SkiePhaseGroup<P, C>.run(
     noinline contextFactory: () -> C,
 ): C where P : ScheduledPhase<C>, P : ForegroundPhase<C> =
     run(C::class, contextFactory)
 
-context(ScheduledPhase.Context)
+context(context: ScheduledPhase.Context)
 fun <P, C : ScheduledPhase.Context> SkiePhaseGroup<P, C>.run(
     contextClass: KClass<C>,
     contextFactory: () -> C,
 ): C where P : ScheduledPhase<C>, P : ForegroundPhase<C> =
     runBlocking(contextClass, contextFactory)
 
-context(ScheduledPhase.Context)
+context(context: ScheduledPhase.Context)
 private fun <P : ScheduledPhase<C>, C : ScheduledPhase.Context> SkiePhaseGroup<P, C>.runBlocking(contextClass: KClass<C>, contextFactory: () -> C): C =
     runBlocking {
         prepareAndExecute(contextClass, contextFactory, SkiePerformanceAnalytics.Kind.Foreground)
     }
 
-context(ScheduledPhase.Context)
+context(context: ScheduledPhase.Context)
 private suspend fun <P : ScheduledPhase<C>, C : ScheduledPhase.Context> SkiePhaseGroup<P, C>.prepareAndExecute(
     contextClass: KClass<C>,
     contextFactory: () -> C,
@@ -98,7 +98,7 @@ private suspend fun <P : ScheduledPhase<C>, C : ScheduledPhase.Context> SkiePhas
 ): C {
     val phasesName = contextClass.nameForLogger.removeSuffix("Phase.Context") + "Phases"
 
-    val (context, phases) = skiePerformanceAnalyticsProducer.log("Initialize$phasesName", kind) {
+    val (context, phases) = context.skiePerformanceAnalyticsProducer.log("Initialize$phasesName", kind) {
         val context = contextFactory()
 
         val phases = buildPhases(context)

--- a/SKIE/kotlin-compiler/core/src/main/kotlin/co/touchlab/skie/phases/util/StatefulScheduledPhase.kt
+++ b/SKIE/kotlin-compiler/core/src/main/kotlin/co/touchlab/skie/phases/util/StatefulScheduledPhase.kt
@@ -4,14 +4,14 @@ import co.touchlab.skie.phases.ScheduledPhase
 
 abstract class StatefulScheduledPhase<C : ScheduledPhase.Context> : ScheduledPhase<C> {
 
-    context(C)
+    context(c: C)
     override suspend fun execute() {
         // Cannot be in the init because the object instance is not available yet.
         check(this::class.objectInstance != null) {
             "StatefulScheduledPhase ${this::class.qualifiedName} must be an object."
         }
 
-        executeStatefulScheduledPhase(this, this@C)
+        c.executeStatefulScheduledPhase(this, c)
     }
 }
 

--- a/SKIE/kotlin-compiler/core/src/main/kotlin/co/touchlab/skie/sir/SirProvider.kt
+++ b/SKIE/kotlin-compiler/core/src/main/kotlin/co/touchlab/skie/sir/SirProvider.kt
@@ -144,15 +144,15 @@ class SirProvider(
         findModuleForKnownExternalClass(oirClass) ?: unknownModule
 }
 
-context(SirProvider)
-fun SirTopLevelDeclarationParent.getExtension(
-    classDeclaration: SirClass,
-): SirExtension =
-    getExtension(classDeclaration, this)
-
-context(SirPhase.Context)
+context(sirProvider: SirProvider)
 fun SirTopLevelDeclarationParent.getExtension(
     classDeclaration: SirClass,
 ): SirExtension =
     sirProvider.getExtension(classDeclaration, this)
+
+context(context: SirPhase.Context)
+fun SirTopLevelDeclarationParent.getExtension(
+    classDeclaration: SirClass,
+): SirExtension =
+    context.sirProvider.getExtension(classDeclaration, this)
 

--- a/SKIE/kotlin-compiler/core/src/main/kotlin/co/touchlab/skie/sir/element/SirClass.kt
+++ b/SKIE/kotlin-compiler/core/src/main/kotlin/co/touchlab/skie/sir/element/SirClass.kt
@@ -124,7 +124,7 @@ class SirClass(
 
     companion object {
 
-        context(SirDeclarationParent)
+        context(sirDeclarationParent: SirDeclarationParent)
         operator fun invoke(
             baseName: String,
             kind: Kind = Kind.Class,
@@ -141,7 +141,7 @@ class SirClass(
         ): SirClass =
             SirClass(
                 baseName = baseName,
-                parent = this@SirDeclarationParent,
+                parent = sirDeclarationParent,
                 kind = kind,
                 modality = modality,
                 visibility = visibility,

--- a/SKIE/kotlin-compiler/core/src/main/kotlin/co/touchlab/skie/sir/element/SirConditionalConstraint.kt
+++ b/SKIE/kotlin-compiler/core/src/main/kotlin/co/touchlab/skie/sir/element/SirConditionalConstraint.kt
@@ -17,14 +17,14 @@ class SirConditionalConstraint(
 
     companion object {
 
-        context(SirConditionalConstraintParent)
+        context(sirConditionalConstraintParent: SirConditionalConstraintParent)
         operator fun invoke(
             typeParameter: SirTypeParameter,
             bounds: List<SirTypeParameter.Bound> = emptyList(),
         ): SirConditionalConstraint =
             SirConditionalConstraint(
                 typeParameter = typeParameter,
-                parent = this@SirConditionalConstraintParent,
+                parent = sirConditionalConstraintParent,
                 bounds = bounds,
             )
     }

--- a/SKIE/kotlin-compiler/core/src/main/kotlin/co/touchlab/skie/sir/element/SirConstructor.kt
+++ b/SKIE/kotlin-compiler/core/src/main/kotlin/co/touchlab/skie/sir/element/SirConstructor.kt
@@ -38,7 +38,7 @@ class SirConstructor(
 
     companion object {
 
-        context(SirDeclarationNamespace)
+        context(sirDeclarationNamespace: SirDeclarationNamespace)
         operator fun invoke(
             visibility: SirVisibility = SirVisibility.Public,
             isHidden: Boolean = false,
@@ -50,7 +50,7 @@ class SirConstructor(
             isWrappedBySkie: Boolean = false,
         ): SirConstructor =
             SirConstructor(
-                parent = this@SirDeclarationNamespace,
+                parent = sirDeclarationNamespace,
                 visibility = visibility,
                 isHidden = isHidden,
                 attributes = attributes,

--- a/SKIE/kotlin-compiler/core/src/main/kotlin/co/touchlab/skie/sir/element/SirEnumCase.kt
+++ b/SKIE/kotlin-compiler/core/src/main/kotlin/co/touchlab/skie/sir/element/SirEnumCase.kt
@@ -21,13 +21,13 @@ class SirEnumCase(
 
     companion object {
 
-        context(SirClass)
+        context(sirClass: SirClass)
         operator fun invoke(
             simpleName: String,
         ): SirEnumCase =
             SirEnumCase(
                 simpleName = simpleName,
-                parent = this@SirClass,
+                parent = sirClass,
             )
     }
 }

--- a/SKIE/kotlin-compiler/core/src/main/kotlin/co/touchlab/skie/sir/element/SirEnumCaseAssociatedValue.kt
+++ b/SKIE/kotlin-compiler/core/src/main/kotlin/co/touchlab/skie/sir/element/SirEnumCaseAssociatedValue.kt
@@ -14,13 +14,13 @@ class SirEnumCaseAssociatedValue(
 
     companion object {
 
-        context(SirEnumCase)
+        context(sirEnumCase: SirEnumCase)
         operator fun invoke(
             type: SirType,
         ): SirEnumCaseAssociatedValue =
             SirEnumCaseAssociatedValue(
                 type = type,
-                parent = this@SirEnumCase,
+                parent = sirEnumCase,
             )
     }
 }

--- a/SKIE/kotlin-compiler/core/src/main/kotlin/co/touchlab/skie/sir/element/SirExtension.kt
+++ b/SKIE/kotlin-compiler/core/src/main/kotlin/co/touchlab/skie/sir/element/SirExtension.kt
@@ -34,7 +34,7 @@ class SirExtension(
 
     companion object {
 
-        context(SirTopLevelDeclarationParent)
+        context(sirTopLevelDeclarationParent: SirTopLevelDeclarationParent)
         operator fun invoke(
             classDeclaration: SirClass,
             attributes: List<String> = emptyList(),
@@ -42,7 +42,7 @@ class SirExtension(
         ): SirExtension =
             SirExtension(
                 classDeclaration = classDeclaration,
-                parent = this@SirTopLevelDeclarationParent,
+                parent = sirTopLevelDeclarationParent,
                 superTypes = superTypes,
                 attributes = attributes,
             )

--- a/SKIE/kotlin-compiler/core/src/main/kotlin/co/touchlab/skie/sir/element/SirGetter.kt
+++ b/SKIE/kotlin-compiler/core/src/main/kotlin/co/touchlab/skie/sir/element/SirGetter.kt
@@ -19,13 +19,13 @@ class SirGetter(
 
     companion object {
 
-        context(SirProperty)
+        context(sirProperty: SirProperty)
         operator fun invoke(
             throws: Boolean = false,
             attributes: List<String> = emptyList(),
         ): SirGetter =
             SirGetter(
-                property = this@SirProperty,
+                property = sirProperty,
                 throws = throws,
                 attributes = attributes,
             )

--- a/SKIE/kotlin-compiler/core/src/main/kotlin/co/touchlab/skie/sir/element/SirProperty.kt
+++ b/SKIE/kotlin-compiler/core/src/main/kotlin/co/touchlab/skie/sir/element/SirProperty.kt
@@ -85,16 +85,16 @@ class SirProperty(
 
     companion object {
 
-        context(SirDeclarationParent)
+        context(sirDeclarationParent: SirDeclarationParent)
         operator fun invoke(
             identifier: String,
             type: SirType,
             visibility: SirVisibility = SirVisibility.Public,
-            modality: SirModality = coerceModalityForSimpleFunctionOrProperty(),
+            modality: SirModality = sirDeclarationParent.coerceModalityForSimpleFunctionOrProperty(),
             isAbstract: Boolean = false,
             isReplaced: Boolean = false,
             isHidden: Boolean = false,
-            scope: SirScope = coerceScope(SirScope.Member),
+            scope: SirScope = sirDeclarationParent.coerceScope(SirScope.Member),
             deprecationLevel: DeprecationLevel = DeprecationLevel.None,
             isFakeOverride: Boolean = false,
             isWrappedBySkie: Boolean = false,
@@ -104,7 +104,7 @@ class SirProperty(
         ): SirProperty =
             SirProperty(
                 identifier = identifier,
-                parent = this@SirDeclarationParent,
+                parent = sirDeclarationParent,
                 type = type,
                 visibility = visibility,
                 modality = modality,

--- a/SKIE/kotlin-compiler/core/src/main/kotlin/co/touchlab/skie/sir/element/SirSetter.kt
+++ b/SKIE/kotlin-compiler/core/src/main/kotlin/co/touchlab/skie/sir/element/SirSetter.kt
@@ -24,14 +24,14 @@ class SirSetter(
 
     companion object {
 
-        context(SirProperty)
+        context(sirProperty: SirProperty)
         operator fun invoke(
             throws: Boolean = false,
             attributes: List<String> = emptyList(),
             modifiers: List<Modifier> = emptyList(),
         ): SirSetter =
             SirSetter(
-                property = this@SirProperty,
+                property = sirProperty,
                 throws = throws,
                 attributes = attributes,
                 modifiers = modifiers,

--- a/SKIE/kotlin-compiler/core/src/main/kotlin/co/touchlab/skie/sir/element/SirSimpleFunction.kt
+++ b/SKIE/kotlin-compiler/core/src/main/kotlin/co/touchlab/skie/sir/element/SirSimpleFunction.kt
@@ -66,16 +66,16 @@ class SirSimpleFunction(
 
     companion object {
 
-        context(SirDeclarationParent)
+        context(sirDeclarationParent: SirDeclarationParent)
         operator fun invoke(
             identifier: String,
             returnType: SirType,
             visibility: SirVisibility = SirVisibility.Public,
-            modality: SirModality = coerceModalityForSimpleFunctionOrProperty(),
+            modality: SirModality = sirDeclarationParent.coerceModalityForSimpleFunctionOrProperty(),
             isAbstract: Boolean = false,
             isReplaced: Boolean = false,
             isHidden: Boolean = false,
-            scope: SirScope = coerceScope(SirScope.Member),
+            scope: SirScope = sirDeclarationParent.coerceScope(SirScope.Member),
             isFakeOverride: Boolean = false,
             isWrappedBySkie: Boolean = false,
             attributes: List<String> = emptyList(),
@@ -86,7 +86,7 @@ class SirSimpleFunction(
         ): SirSimpleFunction =
             SirSimpleFunction(
                 identifier = identifier,
-                parent = this@SirDeclarationParent,
+                parent = sirDeclarationParent,
                 returnType = returnType,
                 visibility = visibility,
                 modality = modality,

--- a/SKIE/kotlin-compiler/core/src/main/kotlin/co/touchlab/skie/sir/element/SirTypeAlias.kt
+++ b/SKIE/kotlin-compiler/core/src/main/kotlin/co/touchlab/skie/sir/element/SirTypeAlias.kt
@@ -66,7 +66,7 @@ class SirTypeAlias(
 
     companion object {
 
-        context(SirDeclarationParent)
+        context(sirDeclarationParent: SirDeclarationParent)
         operator fun invoke(
             baseName: String,
             visibility: SirVisibility = SirVisibility.Public,
@@ -76,7 +76,7 @@ class SirTypeAlias(
         ): SirTypeAlias =
             SirTypeAlias(
                 baseName = baseName,
-                parent = this@SirDeclarationParent,
+                parent = sirDeclarationParent,
                 visibility = visibility,
                 isReplaced = isReplaced,
                 isHidden = isHidden,

--- a/SKIE/kotlin-compiler/core/src/main/kotlin/co/touchlab/skie/sir/element/SirTypeParameter.kt
+++ b/SKIE/kotlin-compiler/core/src/main/kotlin/co/touchlab/skie/sir/element/SirTypeParameter.kt
@@ -32,7 +32,7 @@ class SirTypeParameter(
 
     companion object {
 
-        context(SirTypeParameterParent)
+        context(sirTypeParameterParent: SirTypeParameterParent)
         operator fun invoke(
             name: String,
             bounds: List<Bound> = emptyList(),
@@ -40,12 +40,12 @@ class SirTypeParameter(
         ): SirTypeParameter =
             SirTypeParameter(
                 name = name,
-                parent = this@SirTypeParameterParent,
+                parent = sirTypeParameterParent,
                 bounds = bounds,
                 isPrimaryAssociatedType = isPrimaryAssociatedType,
             )
 
-        context(SirTypeParameterParent)
+        context(sirTypeParameterParent: SirTypeParameterParent)
         operator fun invoke(
             name: String,
             vararg bounds: Bound,

--- a/SKIE/kotlin-compiler/core/src/main/kotlin/co/touchlab/skie/sir/element/SirValueParameter.kt
+++ b/SKIE/kotlin-compiler/core/src/main/kotlin/co/touchlab/skie/sir/element/SirValueParameter.kt
@@ -41,7 +41,7 @@ class SirValueParameter(
 
     companion object {
 
-        context(SirFunction)
+        context(sirFunction: SirFunction)
         operator fun invoke(
             name: String,
             type: SirType,
@@ -53,7 +53,7 @@ class SirValueParameter(
             SirValueParameter(
                 name = name,
                 type = type,
-                parent = this@SirFunction,
+                parent = sirFunction,
                 attributes = attributes,
                 label = label,
                 inout = inout,

--- a/SKIE/kotlin-compiler/core/src/main/kotlin/co/touchlab/skie/sir/signature/Signature.kt
+++ b/SKIE/kotlin-compiler/core/src/main/kotlin/co/touchlab/skie/sir/signature/Signature.kt
@@ -338,7 +338,7 @@ sealed class Signature {
         private val SirFunction.signatureValueParameters: List<ValueParameter>
             get() = valueParameters.map { it.toSignatureParameter() }
 
-        context(SirHierarchyCache)
+        context(sirHierarchyCache: SirHierarchyCache)
         private val SirType.signatureType: Type
             get() {
                 val evaluatedType = this.evaluate()
@@ -354,7 +354,7 @@ sealed class Signature {
                         Type.Class(
                             sirClass = declaration,
                             typeArguments = typeWithoutTypeAliases.typeArguments.map { Type.TypeArgument(it) },
-                            sirHierarchyCache = this@SirHierarchyCache,
+                            sirHierarchyCache = sirHierarchyCache,
                         )
                     }
                     is NullableSirType -> Type.Optional(typeWithoutTypeAliases.type.signatureType)
@@ -369,14 +369,14 @@ sealed class Signature {
                 type = this.type.evaluate().canonicalName,
             )
 
-        context(SirHierarchyCache)
+        context(sirHierarchyCache: SirHierarchyCache)
         private val SirCallableDeclaration.receiver: Receiver
             get() {
                 val (sirClass, constraints) = when (val parent = parent) {
                     // TODO: Now that SirClass can have `conditionalConstraints`, should we put them here?
                     is SirClass -> parent.classDeclaration to emptySet()
                     is SirExtension -> parent.classDeclaration to parent.conditionalConstraints.map {
-                        Receiver.Constraint(it, this@SirHierarchyCache)
+                        Receiver.Constraint(it, sirHierarchyCache)
                     }.toSet()
                     else -> return Receiver.None
                 }
@@ -387,9 +387,9 @@ sealed class Signature {
                 }
             }
 
-        context(SirHierarchyCache)
+        context(sirHierarchyCache: SirHierarchyCache)
         private val SirClass.asReceiverType: Type.Class
-            get() = Type.Class(this, emptyList(), this@SirHierarchyCache)
+            get() = Type.Class(this, emptyList(), sirHierarchyCache)
 
         private val SirCallableDeclaration.signatureScope: Scope
             get() = when (this.scope) {

--- a/SKIE/kotlin-compiler/core/src/main/kotlin/co/touchlab/skie/util/SirDeclaration+resolveCollision.kt
+++ b/SKIE/kotlin-compiler/core/src/main/kotlin/co/touchlab/skie/util/SirDeclaration+resolveCollision.kt
@@ -17,13 +17,13 @@ import co.touchlab.skie.sir.element.SirTypeDeclaration
 import co.touchlab.skie.sir.element.kirClassOrNull
 import co.touchlab.skie.sir.element.resolveAsKirClass
 
-context(SirPhase.Context)
+context(context: SirPhase.Context)
 fun <T : SirTypeDeclaration> T.resolveCollisionWithWarning(collisionReasonProvider: T.() -> String?): Boolean =
     resolveCollisionWithWarning(collisionReasonProvider) {
         baseName += "_"
     }
 
-context(SirPhase.Context)
+context(context: SirPhase.Context)
 fun <T : SirCallableDeclaration> T.resolveCollisionWithWarning(collisionReasonProvider: T.() -> String?): Boolean =
     when (val declaration = this as SirCallableDeclaration) {
         is SirConstructor -> declaration.resolveCollisionWithWarning(collisionReasonProvider as SirConstructor.() -> String?)
@@ -31,7 +31,7 @@ fun <T : SirCallableDeclaration> T.resolveCollisionWithWarning(collisionReasonPr
         is SirProperty -> declaration.resolveCollisionWithWarning(collisionReasonProvider as SirProperty.() -> String?)
     }
 
-context(SirPhase.Context)
+context(context: SirPhase.Context)
 fun SirConstructor.resolveCollisionWithWarning(collisionReasonProvider: SirConstructor.() -> String?): Boolean =
     resolveCollisionWithWarning(collisionReasonProvider) {
         val lastValueParameter = valueParameters.lastOrNull()
@@ -40,19 +40,19 @@ fun SirConstructor.resolveCollisionWithWarning(collisionReasonProvider: SirConst
         lastValueParameter.label = lastValueParameter.labelOrName + "_"
     }
 
-context(SirPhase.Context)
+context(context: SirPhase.Context)
 fun SirProperty.resolveCollisionWithWarning(collisionReasonProvider: SirProperty.() -> String?): Boolean =
     resolveCollisionWithWarning(collisionReasonProvider) {
         identifier += "_"
     }
 
-context(SirPhase.Context)
+context(context: SirPhase.Context)
 fun SirSimpleFunction.resolveCollisionWithWarning(collisionReasonProvider: SirSimpleFunction.() -> String?): Boolean =
     resolveCollisionWithWarning(collisionReasonProvider) {
         identifier += "_"
     }
 
-context(SirPhase.Context)
+context(context: SirPhase.Context)
 fun SirEnumCase.resolveCollisionWithWarning(collisionReasonProvider: SirEnumCase.() -> String?): Boolean =
     resolveCollisionWithWarning(
         collisionReasonProvider = collisionReasonProvider,
@@ -61,7 +61,7 @@ fun SirEnumCase.resolveCollisionWithWarning(collisionReasonProvider: SirEnumCase
         findKirElement = { parent.kirClassOrNull?.enumEntries?.get(index) },
     )
 
-context(SirPhase.Context)
+context(context: SirPhase.Context)
 private inline fun <T : SirCallableDeclaration> T.resolveCollisionWithWarning(
     collisionReasonProvider: T.() -> String?,
     rename: () -> Unit,
@@ -71,12 +71,12 @@ private inline fun <T : SirCallableDeclaration> T.resolveCollisionWithWarning(
         rename = rename,
         getName = { toReadableString() },
         findKirElement = {
-            kirProvider.findCallableDeclaration<SirCallableDeclaration>(this)
-                ?: if (this is SirProperty) kirProvider.findEnumEntry(this) else null
+            context.kirProvider.findCallableDeclaration<SirCallableDeclaration>(this)
+                ?: if (this is SirProperty) context.kirProvider.findEnumEntry(this) else null
         },
     )
 
-context(SirPhase.Context)
+context(context: SirPhase.Context)
 private inline fun <T : SirTypeDeclaration> T.resolveCollisionWithWarning(
     collisionReasonProvider: T.() -> String?,
     rename: () -> Unit,
@@ -88,7 +88,7 @@ private inline fun <T : SirTypeDeclaration> T.resolveCollisionWithWarning(
         findKirElement = { resolveAsKirClass() },
     )
 
-context(SirPhase.Context)
+context(context: SirPhase.Context)
 private inline fun <T, K : KirElement> T.resolveCollisionWithWarning(
     collisionReasonProvider: T.() -> String?,
     rename: () -> Unit,
@@ -122,7 +122,7 @@ private inline fun <T> T.resolveCollision(collisionReasonProvider: T.() -> Strin
     } while (collisionReasonProvider() != null)
 }
 
-context(SirPhase.Context)
+context(context: SirPhase.Context)
 private val KirElement.shouldReportCollision: Boolean
     get() = when (this) {
         is KirCallableDeclaration<*> -> !configuration[SuppressSkieWarning.NameCollision]
@@ -131,14 +131,14 @@ private val KirElement.shouldReportCollision: Boolean
         else -> true
     }
 
-context(SirPhase.Context)
+context(context: SirPhase.Context)
 private fun reportCollision(
     originalName: String,
     newName: String,
     collisionReason: String,
     source: KirElement,
 ) {
-    kirReporter.warning(
+    context.kirReporter.warning(
         message = "'$originalName' was renamed to '$newName' because of a name collision with $collisionReason. " +
             "Consider resolving the conflict either by changing the name in Kotlin, or via the @ObjCName annotation. " +
             "You can also suppress this warning using the 'SuppressSkieWarning.NameCollision' configuration. " +

--- a/SKIE/kotlin-compiler/core/src/main/kotlin/co/touchlab/skie/util/parallel/ParallelFlatMap.kt
+++ b/SKIE/kotlin-compiler/core/src/main/kotlin/co/touchlab/skie/util/parallel/ParallelFlatMap.kt
@@ -2,6 +2,6 @@ package co.touchlab.skie.util.parallel
 
 import co.touchlab.skie.phases.ScheduledPhase
 
-context(ScheduledPhase.Context)
+context(context: ScheduledPhase.Context)
 suspend fun <T, R> Collection<T>.parallelFlatMap(optimalChunkSize: Int = 100, transform: suspend (T) -> Iterable<R>): List<R> =
     parallelMap(optimalChunkSize, transform).flatten()

--- a/SKIE/kotlin-compiler/core/src/main/kotlin/co/touchlab/skie/util/parallel/ParallelMap.kt
+++ b/SKIE/kotlin-compiler/core/src/main/kotlin/co/touchlab/skie/util/parallel/ParallelMap.kt
@@ -8,9 +8,9 @@ import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.withContext
 
-context(ScheduledPhase.Context)
+context(context: ScheduledPhase.Context)
 suspend fun <T, R> Collection<T>.parallelMap(optimalChunkSize: Int = 100, transform: suspend (T) -> R): List<R> {
-    if (SkieConfigurationFlag.Build_ParallelSkieCompilation.isDisabled) {
+    if (context.run { SkieConfigurationFlag.Build_ParallelSkieCompilation.isDisabled }) {
         return map { transform(it) }
     }
 

--- a/SKIE/kotlin-compiler/linker-plugin/src/main/kotlin/co/touchlab/skie/configuration/provider/descriptor/DescriptorConfigurationProvider.kt
+++ b/SKIE/kotlin-compiler/linker-plugin/src/main/kotlin/co/touchlab/skie/configuration/provider/descriptor/DescriptorConfigurationProvider.kt
@@ -139,19 +139,19 @@ class DescriptorConfigurationProvider(
         }
 }
 
-context(ForegroundPhase.Context)
+context(context: ForegroundPhase.Context)
 val ClassDescriptor.configuration: ClassConfiguration
-    get() = descriptorConfigurationProvider.getConfiguration(this)
+    get() = context.descriptorConfigurationProvider.getConfiguration(this)
 
-context(ForegroundPhase.Context)
+context(context: ForegroundPhase.Context)
 val SimpleFunctionDescriptor.configuration: SimpleFunctionConfiguration
-    get() = descriptorConfigurationProvider.getConfiguration(this)
+    get() = context.descriptorConfigurationProvider.getConfiguration(this)
 
-context(ForegroundPhase.Context)
+context(context: ForegroundPhase.Context)
 val ConstructorDescriptor.configuration: ConstructorConfiguration
-    get() = descriptorConfigurationProvider.getConfiguration(this)
+    get() = context.descriptorConfigurationProvider.getConfiguration(this)
 
-context(ForegroundPhase.Context)
+context(context: ForegroundPhase.Context)
 val FunctionDescriptor.configuration: FunctionConfiguration
     get() = when (this) {
         is SimpleFunctionDescriptor -> configuration

--- a/SKIE/kotlin-compiler/linker-plugin/src/main/kotlin/co/touchlab/skie/kir/irbuilder/DeclarationTemplate.kt
+++ b/SKIE/kotlin-compiler/linker-plugin/src/main/kotlin/co/touchlab/skie/kir/irbuilder/DeclarationTemplate.kt
@@ -11,15 +11,15 @@ interface DeclarationTemplate<D : DeclarationDescriptor> {
 
     val descriptor: D
 
-    context(MutableDescriptorProvider)
+    context(mutableDescriptorProvider: MutableDescriptorProvider)
     fun registerExposedDescriptor()
 
-    context(SymbolTablePhase.Context)
+    context(context: SymbolTablePhase.Context)
     fun declareSymbol()
 
-    context(KotlinIrPhase.Context)
+    context(context: KotlinIrPhase.Context)
     fun generateIrDeclaration(parent: IrDeclarationContainer, generatorContext: GeneratorContext)
 
-    context(KotlinIrPhase.Context)
+    context(context: KotlinIrPhase.Context)
     fun generateIrBody()
 }

--- a/SKIE/kotlin-compiler/linker-plugin/src/main/kotlin/co/touchlab/skie/kir/irbuilder/Namespace.kt
+++ b/SKIE/kotlin-compiler/linker-plugin/src/main/kotlin/co/touchlab/skie/kir/irbuilder/Namespace.kt
@@ -12,15 +12,15 @@ interface Namespace<D : DeclarationDescriptor> {
 
     val sourceElement: SourceElement
 
-    context(MutableDescriptorProvider)
+    context(mutableDescriptorProvider: MutableDescriptorProvider)
     fun addTemplate(declarationTemplate: DeclarationTemplate<*>)
 
-    context(SymbolTablePhase.Context)
+    context(context: SymbolTablePhase.Context)
     fun registerSymbols()
 
-    context(KotlinIrPhase.Context)
+    context(context: KotlinIrPhase.Context)
     fun generateIrDeclarations()
 
-    context(KotlinIrPhase.Context)
+    context(context: KotlinIrPhase.Context)
     fun generateIrBodies()
 }

--- a/SKIE/kotlin-compiler/linker-plugin/src/main/kotlin/co/touchlab/skie/kir/irbuilder/impl/DeclarationBuilderImpl.kt
+++ b/SKIE/kotlin-compiler/linker-plugin/src/main/kotlin/co/touchlab/skie/kir/irbuilder/impl/DeclarationBuilderImpl.kt
@@ -128,18 +128,18 @@ class DeclarationBuilderImpl(
         return declarationTemplate.descriptor
     }
 
-    context(SymbolTablePhase.Context)
+    context(context: SymbolTablePhase.Context)
     fun declareSymbols() {
         allNamespaces.forEach {
             it.registerSymbols()
         }
     }
 
-    context(KotlinIrPhase.Context)
+    context(context: KotlinIrPhase.Context)
     fun generateIr() {
-        this.mainIrModuleFragment = moduleFragment
+        this.mainIrModuleFragment = context.moduleFragment
 
-        fixPrivateTypeParametersSymbolsFromOldKLibs(skieSymbolTable)
+        fixPrivateTypeParametersSymbolsFromOldKLibs(context.skieSymbolTable)
 
         allNamespaces.forEach {
             it.generateIrDeclarations()

--- a/SKIE/kotlin-compiler/linker-plugin/src/main/kotlin/co/touchlab/skie/kir/irbuilder/impl/namespace/BaseNamespace.kt
+++ b/SKIE/kotlin-compiler/linker-plugin/src/main/kotlin/co/touchlab/skie/kir/irbuilder/impl/namespace/BaseNamespace.kt
@@ -18,43 +18,43 @@ abstract class BaseNamespace<D : DeclarationDescriptor> : Namespace<D> {
 
     private val templates = mutableListOf<DeclarationTemplate<*>>()
 
-    context(MutableDescriptorProvider)
+    context(mutableDescriptorProvider: MutableDescriptorProvider)
     override fun addTemplate(declarationTemplate: DeclarationTemplate<*>) {
         templates.add(declarationTemplate)
 
         registerDescriptorProvider(declarationTemplate)
     }
 
-    context(SymbolTablePhase.Context)
+    context(context: SymbolTablePhase.Context)
     override fun registerSymbols() {
         templates.forEach {
             it.declareSymbol()
         }
     }
 
-    context(MutableDescriptorProvider)
+    context(mutableDescriptorProvider: MutableDescriptorProvider)
     private fun registerDescriptorProvider(declarationTemplate: DeclarationTemplate<*>) {
         addDescriptorIntoDescriptorHierarchy(declarationTemplate.descriptor)
         addDescriptorIntoDescriptorProvider(declarationTemplate)
     }
 
-    context(MutableDescriptorProvider)
+    context(mutableDescriptorProvider: MutableDescriptorProvider)
     private fun addDescriptorIntoDescriptorProvider(declarationTemplate: DeclarationTemplate<*>) {
         declarationTemplate.registerExposedDescriptor()
     }
 
-    context(KotlinIrPhase.Context)
+    context(context: KotlinIrPhase.Context)
     override fun generateIrDeclarations() {
         @Suppress("DEPRECATION")
         val generatorContext = GeneratorContext(
             Psi2IrConfiguration(),
             descriptor.module,
-            pluginContext.bindingContext,
-            pluginContext.languageVersionSettings,
-            skieSymbolTable.kotlinSymbolTable,
+            context.pluginContext.bindingContext,
+            context.pluginContext.languageVersionSettings,
+            context.skieSymbolTable.kotlinSymbolTable,
             GeneratorExtensions(),
-            pluginContext.typeTranslator,
-            pluginContext.irBuiltIns,
+            context.pluginContext.typeTranslator,
+            context.pluginContext.irBuiltIns,
             null,
         )
 
@@ -65,7 +65,7 @@ abstract class BaseNamespace<D : DeclarationDescriptor> : Namespace<D> {
         }
     }
 
-    context(KotlinIrPhase.Context)
+    context(context: KotlinIrPhase.Context)
     override fun generateIrBodies() {
         templates.forEach {
             it.generateIrBody()
@@ -74,6 +74,6 @@ abstract class BaseNamespace<D : DeclarationDescriptor> : Namespace<D> {
 
     protected abstract fun addDescriptorIntoDescriptorHierarchy(declarationDescriptor: DeclarationDescriptor)
 
-    context(KotlinIrPhase.Context)
+    context(context: KotlinIrPhase.Context)
     protected abstract fun generateNamespaceIr(): IrDeclarationContainer
 }

--- a/SKIE/kotlin-compiler/linker-plugin/src/main/kotlin/co/touchlab/skie/kir/irbuilder/impl/namespace/DeserializedClassNamespace.kt
+++ b/SKIE/kotlin-compiler/linker-plugin/src/main/kotlin/co/touchlab/skie/kir/irbuilder/impl/namespace/DeserializedClassNamespace.kt
@@ -48,7 +48,7 @@ class DeserializedClassNamespace(
         (descriptor.constructors as MutableCollection).add(constructorDescriptor)
     }
 
-    context(KotlinIrPhase.Context)
+    context(context: KotlinIrPhase.Context)
     override fun generateNamespaceIr(): IrDeclarationContainer =
-        skieSymbolTable.descriptorExtension.referenceClass(descriptor).owner
+        context.skieSymbolTable.descriptorExtension.referenceClass(descriptor).owner
 }

--- a/SKIE/kotlin-compiler/linker-plugin/src/main/kotlin/co/touchlab/skie/kir/irbuilder/impl/namespace/DeserializedPackageNamespace.kt
+++ b/SKIE/kotlin-compiler/linker-plugin/src/main/kotlin/co/touchlab/skie/kir/irbuilder/impl/namespace/DeserializedPackageNamespace.kt
@@ -35,7 +35,7 @@ class DeserializedPackageNamespace(
         descriptor.getMemberScope().addFunctionDescriptorToImpl(functionDescriptor)
     }
 
-    context(KotlinIrPhase.Context)
+    context(context: KotlinIrPhase.Context)
     override fun generateNamespaceIr(): IrDeclarationContainer =
-        skieSymbolTable.kotlinSymbolTable.referenceFunction(existingMember).owner.getPackageFragment()
+        context.skieSymbolTable.kotlinSymbolTable.referenceFunction(existingMember).owner.getPackageFragment()
 }

--- a/SKIE/kotlin-compiler/linker-plugin/src/main/kotlin/co/touchlab/skie/kir/irbuilder/impl/namespace/NewFileNamespace.kt
+++ b/SKIE/kotlin-compiler/linker-plugin/src/main/kotlin/co/touchlab/skie/kir/irbuilder/impl/namespace/NewFileNamespace.kt
@@ -51,7 +51,7 @@ class NewFileNamespace private constructor(
         packageContent.add(declarationDescriptor)
     }
 
-    context(KotlinIrPhase.Context)
+    context(contextCtx: KotlinIrPhase.Context)
     override fun generateNamespaceIr(): IrDeclarationContainer {
         val fileEntry = DummyIrFileEntry(sourceFile.nameOrError)
 

--- a/SKIE/kotlin-compiler/linker-plugin/src/main/kotlin/co/touchlab/skie/kir/irbuilder/impl/template/BaseDeclarationTemplate.kt
+++ b/SKIE/kotlin-compiler/linker-plugin/src/main/kotlin/co/touchlab/skie/kir/irbuilder/impl/template/BaseDeclarationTemplate.kt
@@ -17,7 +17,7 @@ import org.jetbrains.kotlin.psi2ir.generators.SyntheticDeclarationsGenerator
 abstract class BaseDeclarationTemplate<D : DeclarationDescriptor, IR : IrDeclaration, S : IrBindableSymbol<D, IR>> :
     DeclarationTemplate<D> {
 
-    context(KotlinIrPhase.Context)
+    context(context: KotlinIrPhase.Context)
     override fun generateIrDeclaration(parent: IrDeclarationContainer, generatorContext: GeneratorContext) {
         createDeclarationStubsIfIrLazyClass(parent)
 
@@ -36,18 +36,18 @@ abstract class BaseDeclarationTemplate<D : DeclarationDescriptor, IR : IrDeclara
         parent.declarations
     }
 
-    context(KotlinIrPhase.Context)
+    context(context: KotlinIrPhase.Context)
     override fun generateIrBody() {
         val symbol = getSymbol()
 
-        val declarationIrBuilder = DeclarationIrBuilder(pluginContext.generatorContext, symbol, startOffset = 0, endOffset = 0)
+        val declarationIrBuilder = DeclarationIrBuilder(context.pluginContext.generatorContext, symbol, startOffset = 0, endOffset = 0)
 
         initializeBody(symbol.owner, declarationIrBuilder)
     }
 
-    context(KotlinIrPhase.Context)
+    context(context: KotlinIrPhase.Context)
     protected abstract fun getSymbol(): S
 
-    context(KotlinIrPhase.Context)
+    context(context: KotlinIrPhase.Context)
     protected abstract fun initializeBody(declaration: IR, declarationIrBuilder: DeclarationIrBuilder)
 }

--- a/SKIE/kotlin-compiler/linker-plugin/src/main/kotlin/co/touchlab/skie/kir/irbuilder/impl/template/FunctionTemplate.kt
+++ b/SKIE/kotlin-compiler/linker-plugin/src/main/kotlin/co/touchlab/skie/kir/irbuilder/impl/template/FunctionTemplate.kt
@@ -58,14 +58,14 @@ class FunctionTemplate(
         descriptor.isSuspend = functionBuilder.isSuspend
     }
 
-    context(MutableDescriptorProvider)
+    context(mutableDescriptorProvider: MutableDescriptorProvider)
     override fun registerExposedDescriptor() {
-        this@MutableDescriptorProvider.exposeCallableMember(descriptor)
+        mutableDescriptorProvider.exposeCallableMember(descriptor)
     }
 
-    context(SymbolTablePhase.Context)
+    context(context: SymbolTablePhase.Context)
     override fun declareSymbol() {
-        val signature = skieSymbolTable.signaturer.composeSignature(descriptor)
+        val signature = context.skieSymbolTable.signaturer.composeSignature(descriptor)
             ?: throw IllegalArgumentException("Only exported declarations are currently supported. Check declaration visibility.")
 
         // IrRebindableSimpleFunctionPublicSymbol is used so that we can later bind it to the correct declaration which cannot be created before the symbol table is validated to not contain any unbound symbols.
@@ -78,17 +78,17 @@ class FunctionTemplate(
             }
         }
 
-        val declaration = skieSymbolTable.kotlinSymbolTable.declareSimpleFunction(signature, symbolFactory, functionFactory)
+        val declaration = context.skieSymbolTable.kotlinSymbolTable.declareSimpleFunction(signature, symbolFactory, functionFactory)
         // But the symbol cannot be bounded otherwise DeclarationBuilder will not to generate the declaration (because it thinks it already exists).
         (declaration.symbol as? IrRebindableSimpleFunctionPublicSymbol)?.unbind()
     }
 
-    context(KotlinIrPhase.Context)
+    context(context: KotlinIrPhase.Context)
     override fun getSymbol(): IrSimpleFunctionSymbol =
-        skieSymbolTable.descriptorExtension.referenceSimpleFunction(descriptor)
+        context.skieSymbolTable.descriptorExtension.referenceSimpleFunction(descriptor)
 
-    context(KotlinIrPhase.Context)
+    context(context: KotlinIrPhase.Context)
     override fun initializeBody(declaration: IrSimpleFunction, declarationIrBuilder: DeclarationIrBuilder) {
-        declaration.body = irBodyBuilder(this@Context, declarationIrBuilder, declaration)
+        declaration.body = irBodyBuilder(context, declarationIrBuilder, declaration)
     }
 }

--- a/SKIE/kotlin-compiler/linker-plugin/src/main/kotlin/co/touchlab/skie/kir/irbuilder/impl/template/SecondaryConstructorTemplate.kt
+++ b/SKIE/kotlin-compiler/linker-plugin/src/main/kotlin/co/touchlab/skie/kir/irbuilder/impl/template/SecondaryConstructorTemplate.kt
@@ -54,14 +54,14 @@ class SecondaryConstructorTemplate(
         descriptor.returnType = namespace.descriptor.defaultType
     }
 
-    context(MutableDescriptorProvider)
+    context(mutableDescriptorProvider: MutableDescriptorProvider)
     override fun registerExposedDescriptor() {
-        this@MutableDescriptorProvider.exposeCallableMember(descriptor)
+        mutableDescriptorProvider.exposeCallableMember(descriptor)
     }
 
-    context(SymbolTablePhase.Context)
+    context(context: SymbolTablePhase.Context)
     override fun declareSymbol() {
-        val signature = skieSymbolTable.signaturer.composeSignature(descriptor)
+        val signature = context.skieSymbolTable.signaturer.composeSignature(descriptor)
             ?: throw IllegalArgumentException("Only exported declarations are currently supported. Check declaration visibility.")
 
         // IrRebindableConstructorPublicSymbol is used so that we can later bind it to the correct declaration which cannot be created before the symbol table is validated to not contain any unbound symbols.
@@ -74,17 +74,17 @@ class SecondaryConstructorTemplate(
             }
         }
 
-        val declaration = skieSymbolTable.kotlinSymbolTable.declareConstructor(signature, symbolFactory, functionFactory)
+        val declaration = context.skieSymbolTable.kotlinSymbolTable.declareConstructor(signature, symbolFactory, functionFactory)
         // But the symbol cannot be bounded otherwise DeclarationBuilder will not to generate the declaration (because it thinks it already exists).
         (declaration.symbol as? IrRebindableConstructorPublicSymbol)?.unbind()
     }
 
-    context(KotlinIrPhase.Context)
+    context(context: KotlinIrPhase.Context)
     override fun getSymbol(): IrConstructorSymbol =
-        skieSymbolTable.descriptorExtension.referenceConstructor(descriptor)
+        context.skieSymbolTable.descriptorExtension.referenceConstructor(descriptor)
 
-    context(KotlinIrPhase.Context)
+    context(context: KotlinIrPhase.Context)
     override fun initializeBody(declaration: IrConstructor, declarationIrBuilder: DeclarationIrBuilder) {
-        declaration.body = irBodyBuilder(this@Context, declarationIrBuilder, declaration)
+        declaration.body = irBodyBuilder(context, declarationIrBuilder, declaration)
     }
 }

--- a/SKIE/kotlin-compiler/linker-plugin/src/main/kotlin/co/touchlab/skie/kir/irbuilder/util/IrSimpleFunctionBuilder.kt
+++ b/SKIE/kotlin-compiler/linker-plugin/src/main/kotlin/co/touchlab/skie/kir/irbuilder/util/IrSimpleFunctionBuilder.kt
@@ -2,6 +2,7 @@ package co.touchlab.skie.kir.irbuilder.util
 
 import co.touchlab.skie.phases.KotlinIrPhase
 import co.touchlab.skie.phases.irFactory
+import co.touchlab.skie.phases.pluginContext
 import org.jetbrains.kotlin.backend.common.lower.DeclarationIrBuilder
 import org.jetbrains.kotlin.descriptors.DescriptorVisibility
 import org.jetbrains.kotlin.descriptors.Modality
@@ -16,7 +17,7 @@ import org.jetbrains.kotlin.ir.types.IrType
 import org.jetbrains.kotlin.ir.util.patchDeclarationParents
 import org.jetbrains.kotlin.name.Name
 
-context(KotlinIrPhase.Context)
+context(context: KotlinIrPhase.Context)
 fun IrBuilderWithScope.irSimpleFunction(
     name: Name,
     visibility: DescriptorVisibility,
@@ -34,7 +35,7 @@ fun IrBuilderWithScope.irSimpleFunction(
     isFakeOverride: Boolean = origin == IrDeclarationOrigin.FAKE_OVERRIDE,
     body: DeclarationIrBuilder.() -> IrBody,
 ): IrSimpleFunction =
-    irFactory.createSimpleFunction(
+    context.irFactory.createSimpleFunction(
         startOffset = startOffset,
         endOffset = endOffset,
         origin = origin,
@@ -52,7 +53,7 @@ fun IrBuilderWithScope.irSimpleFunction(
         isExpect = isExpect,
         isFakeOverride = isFakeOverride,
     ).apply {
-        val irDeclarationBuilder = DeclarationIrBuilder(context, symbol, startOffset = startOffset, endOffset = endOffset)
+        val irDeclarationBuilder = DeclarationIrBuilder(context.pluginContext.generatorContext, symbol, startOffset = startOffset, endOffset = endOffset)
 
         this.body = irDeclarationBuilder.body()
 

--- a/SKIE/kotlin-compiler/linker-plugin/src/main/kotlin/co/touchlab/skie/kir/type/translation/KirCustomTypeMapper.kt
+++ b/SKIE/kotlin-compiler/linker-plugin/src/main/kotlin/co/touchlab/skie/kir/type/translation/KirCustomTypeMapper.kt
@@ -8,7 +8,7 @@ interface KirCustomTypeMapper {
 
     val mappedClassId: ClassId
 
-    context(KirTypeParameterScope)
+    context(kirTypeParameterScope: KirTypeParameterScope)
     fun mapType(
         mappedSuperType: KotlinType,
     ): NonNullReferenceKirType

--- a/SKIE/kotlin-compiler/linker-plugin/src/main/kotlin/co/touchlab/skie/kir/type/translation/KirCustomTypeMappers.kt
+++ b/SKIE/kotlin-compiler/linker-plugin/src/main/kotlin/co/touchlab/skie/kir/type/translation/KirCustomTypeMappers.kt
@@ -51,7 +51,7 @@ class KirCustomTypeMappers(
         }
     }
 
-    context(KirTypeParameterScope)
+    context(kirTypeParameterScope: KirTypeParameterScope)
     fun mapTypeIfApplicable(kotlinType: KotlinType): NonNullReferenceKirType? {
         val typeMappingMatches = (listOf(kotlinType) + kotlinType.supertypes()).mapNotNull { type ->
             (type.constructor.declarationDescriptor as? ClassDescriptor)?.let { descriptor ->
@@ -69,7 +69,7 @@ class KirCustomTypeMappers(
         }
 
         return mostSpecificMatches.firstOrNull()?.let {
-            withTypeParameterScopeFor(it.type) { it.mapper.mapType(it.type) } ?: SpecialOirKirType(SpecialReferenceOirType.Id)
+            kirTypeParameterScope.withTypeParameterScopeFor(it.type) { it.mapper.mapType(it.type) } ?: SpecialOirKirType(SpecialReferenceOirType.Id)
         }
     }
 
@@ -113,7 +113,7 @@ class KirCustomTypeMappers(
         private val kirClass: KirClass,
     ) : KirCustomTypeMapper {
 
-        context(KirTypeParameterScope)
+        context(kirTypeParameterScope: KirTypeParameterScope)
         override fun mapType(mappedSuperType: KotlinType): NonNullReferenceKirType =
             kirClass.defaultType
     }
@@ -125,7 +125,7 @@ class KirCustomTypeMappers(
 
         override val mappedClassId = ClassId.topLevel(mappedClassFqName)
 
-        context(KirTypeParameterScope)
+        context(kirTypeParameterScope: KirTypeParameterScope)
         override fun mapType(
             mappedSuperType: KotlinType,
         ): NonNullReferenceKirType {
@@ -148,7 +148,7 @@ class KirCustomTypeMappers(
         override val mappedClassId: ClassId
             get() = StandardNames.getFunctionClassId(parameterCount)
 
-        context(KirTypeParameterScope)
+        context(kirTypeParameterScope: KirTypeParameterScope)
         override fun mapType(
             mappedSuperType: KotlinType,
         ): NonNullReferenceKirType =

--- a/SKIE/kotlin-compiler/linker-plugin/src/main/kotlin/co/touchlab/skie/kir/type/translation/KirDeclarationTypeTranslator.kt
+++ b/SKIE/kotlin-compiler/linker-plugin/src/main/kotlin/co/touchlab/skie/kir/type/translation/KirDeclarationTypeTranslator.kt
@@ -36,7 +36,7 @@ class KirDeclarationTypeTranslator(
 
     private val nullableNSErrorType = kirBuiltins.NSError.defaultType.withNullabilityOf(true)
 
-    context(KirTypeParameterScope)
+    context(kirTypeParameterScope: KirTypeParameterScope)
     internal fun mapValueParameterType(
         functionDescriptor: FunctionDescriptor,
         valueParameterDescriptor: ParameterDescriptor?,
@@ -52,7 +52,7 @@ class KirDeclarationTypeTranslator(
             }
         }
 
-    context(KirTypeParameterScope)
+    context(kirTypeParameterScope: KirTypeParameterScope)
     internal fun mapReturnType(
         descriptor: FunctionDescriptor,
         returnBridge: MethodBridge.ReturnValue,
@@ -75,7 +75,7 @@ class KirDeclarationTypeTranslator(
             -> SpecialReferenceOirType.InstanceType.toKirType()
         }
 
-    context(KirTypeParameterScope)
+    context(kirTypeParameterScope: KirTypeParameterScope)
     private fun mapType(kotlinType: KotlinType, typeBridge: TypeBridge): KirType =
         when (typeBridge) {
             ReferenceBridge -> kirTypeTranslator.mapReferenceType(kotlinType)
@@ -83,7 +83,7 @@ class KirDeclarationTypeTranslator(
             is ValueTypeBridge -> mapValueType(kotlinType, typeBridge)
         }
 
-    context(KirTypeParameterScope)
+    context(kirTypeParameterScope: KirTypeParameterScope)
     private fun mapSuspendCompletionType(kotlinType: KotlinType, useUnitCompletion: Boolean): BlockPointerKirType {
         val resultType = if (useUnitCompletion) {
             null
@@ -103,7 +103,7 @@ class KirDeclarationTypeTranslator(
         )
     }
 
-    context(KirTypeParameterScope)
+    context(kirTypeParameterScope: KirTypeParameterScope)
     private fun mapFunctionType(
         kotlinType: KotlinType,
         typeBridge: BlockPointerBridge,

--- a/SKIE/kotlin-compiler/linker-plugin/src/main/kotlin/co/touchlab/skie/kir/type/translation/KirTypeParameterScope.kt
+++ b/SKIE/kotlin-compiler/linker-plugin/src/main/kotlin/co/touchlab/skie/kir/type/translation/KirTypeParameterScope.kt
@@ -14,7 +14,7 @@ interface KirTypeParameterScope {
 
     val parent: KirTypeParameterScope?
 
-    context(DescriptorKirProvider)
+    context(descriptorKirProvider: DescriptorKirProvider)
     fun getTypeParameterUsage(typeParameterDescriptor: TypeParameterDescriptor?): TypeParameterUsageKirType? =
         parent?.getTypeParameterUsage(typeParameterDescriptor)
 
@@ -49,7 +49,7 @@ class KirTypeParameterClassScope(
     private val typeParameters: List<KirTypeParameter>,
 ) : KirTypeParameterScope {
 
-    context(DescriptorKirProvider)
+    context(descriptorKirProvider: DescriptorKirProvider)
     override fun getTypeParameterUsage(typeParameterDescriptor: TypeParameterDescriptor?): TypeParameterUsageKirType? {
         if (typeParameterDescriptor == null) {
             return null
@@ -57,7 +57,7 @@ class KirTypeParameterClassScope(
 
         return typeParameters
             .firstOrNull {
-                val descriptor = getTypeParameterDescriptor(it)
+                val descriptor = descriptorKirProvider.getTypeParameterDescriptor(it)
 
                 descriptor == typeParameterDescriptor || (descriptor.isCapturedFromOuterDeclaration && descriptor.original == typeParameterDescriptor)
             }

--- a/SKIE/kotlin-compiler/linker-plugin/src/main/kotlin/co/touchlab/skie/kir/type/translation/KirTypeTranslator.kt
+++ b/SKIE/kotlin-compiler/linker-plugin/src/main/kotlin/co/touchlab/skie/kir/type/translation/KirTypeTranslator.kt
@@ -35,11 +35,11 @@ class KirTypeTranslator(
     private val customTypeMappers: KirCustomTypeMappers,
 ) : KirTypeTranslatorUtilityScope() {
 
-    context(KirTypeParameterScope)
+    context(kirTypeParameterScope: KirTypeParameterScope)
     fun mapReferenceType(kotlinType: KotlinType): ReferenceKirType =
         mapReferenceTypeIgnoringNullability(kotlinType).withNullabilityOf(kotlinType)
 
-    context(KirTypeParameterScope)
+    context(kirTypeParameterScope: KirTypeParameterScope)
     fun mapReferenceTypeIgnoringNullability(kotlinType: KotlinType): NonNullReferenceKirType {
         mapTypeIfFlow(kotlinType)?.let {
             return it
@@ -51,7 +51,7 @@ class KirTypeTranslator(
 
         if (kotlinType.isTypeParameter()) {
             val genericTypeUsage = with(descriptorKirProvider) {
-                getTypeParameterUsage(TypeUtils.getTypeParameterDescriptorOrNull(kotlinType))
+                kirTypeParameterScope.getTypeParameterUsage(TypeUtils.getTypeParameterDescriptorOrNull(kotlinType))
             }
 
             if (genericTypeUsage != null)
@@ -85,7 +85,7 @@ class KirTypeTranslator(
         return kirClass.toType(typeArgs)
     }
 
-    context(KirTypeParameterScope)
+    context(kirTypeParameterScope: KirTypeParameterScope)
     private fun mapTypeIfFlow(kotlinType: KotlinType): UnresolvedFlowKirType? {
         val supportedFlow = SupportedFlow.from(kotlinType) ?: return null
 
@@ -102,7 +102,7 @@ class KirTypeTranslator(
         }
     }
 
-    context(KirTypeParameterScope)
+    context(kirTypeParameterScope: KirTypeParameterScope)
     private fun KirTypeTranslator.mapTypeArgument(typeProjection: TypeProjection): NonNullReferenceKirType =
         if (typeProjection.isStarProjection) {
             SpecialReferenceOirType.Id.toKirType() // TODO: use Kotlin upper bound.
@@ -127,11 +127,11 @@ class KirTypeTranslator(
         return SpecialReferenceOirType.Id.toKirType()
     }
 
-    context(KirTypeParameterScope)
+    context(kirTypeParameterScope: KirTypeParameterScope)
     fun mapFunctionType(kotlinType: KotlinType, returnsVoid: Boolean): ReferenceKirType =
         mapFunctionTypeIgnoringNullability(kotlinType, returnsVoid).withNullabilityOf(kotlinType)
 
-    context(KirTypeParameterScope)
+    context(kirTypeParameterScope: KirTypeParameterScope)
     fun mapFunctionTypeIgnoringNullability(
         functionType: KotlinType,
         returnsVoid: Boolean,

--- a/SKIE/kotlin-compiler/linker-plugin/src/main/kotlin/co/touchlab/skie/phases/analytics/ClassExportAnalyticsPhase.kt
+++ b/SKIE/kotlin-compiler/linker-plugin/src/main/kotlin/co/touchlab/skie/phases/analytics/ClassExportAnalyticsPhase.kt
@@ -9,13 +9,13 @@ import co.touchlab.skie.phases.konanConfig
 
 object ClassExportAnalyticsPhase : ClassExportPhase {
 
-    context(ClassExportPhase.Context)
+    context(context: ClassExportPhase.Context)
     override suspend fun execute() {
-        analyticsCollector.collectAsync(
-            CommonCompilerConfigurationAnalytics.Producer(konanConfig),
-            SpecificCompilerConfigurationAnalytics.Producer(konanConfig),
-            SkieConfigurationAnalytics.Producer(skieConfigurationData),
-            CompilerEnvironmentAnalytics.Producer(konanConfig),
+        context.analyticsCollector.collectAsync(
+            CommonCompilerConfigurationAnalytics.Producer(context.konanConfig),
+            SpecificCompilerConfigurationAnalytics.Producer(context.konanConfig),
+            SkieConfigurationAnalytics.Producer(context.skieConfigurationData),
+            CompilerEnvironmentAnalytics.Producer(context.konanConfig),
         )
     }
 }

--- a/SKIE/kotlin-compiler/linker-plugin/src/main/kotlin/co/touchlab/skie/phases/analytics/KotlinIrAnalyticsPhase.kt
+++ b/SKIE/kotlin-compiler/linker-plugin/src/main/kotlin/co/touchlab/skie/phases/analytics/KotlinIrAnalyticsPhase.kt
@@ -5,9 +5,9 @@ import co.touchlab.skie.phases.KotlinIrPhase
 
 object KotlinIrAnalyticsPhase : KotlinIrPhase {
 
-    context(KotlinIrPhase.Context)
+    context(context: KotlinIrPhase.Context)
     override suspend fun execute() {
-        analyticsCollector.collectSynchronously(
+        context.analyticsCollector.collectSynchronously(
             ModulesAnalytics.Producer(context),
         )
     }

--- a/SKIE/kotlin-compiler/linker-plugin/src/main/kotlin/co/touchlab/skie/phases/debug/VerifyDescriptorProviderConsistencyPhase.kt
+++ b/SKIE/kotlin-compiler/linker-plugin/src/main/kotlin/co/touchlab/skie/phases/debug/VerifyDescriptorProviderConsistencyPhase.kt
@@ -12,18 +12,18 @@ import org.jetbrains.kotlin.resolve.descriptorUtil.fqNameUnsafe
 
 object VerifyDescriptorProviderConsistencyPhase : KirPhase {
 
-    context(KirPhase.Context)
-    override fun isActive(): Boolean = SkieConfigurationFlag.Debug_VerifyDescriptorProviderConsistency.isEnabled
+    context(context: KirPhase.Context)
+    override fun isActive(): Boolean = context.run { SkieConfigurationFlag.Debug_VerifyDescriptorProviderConsistency.isEnabled }
 
-    context(KirPhase.Context)
+    context(context: KirPhase.Context)
     override suspend fun execute() {
-        val objCExportedInterface = objCExportedInterfaceProvider.objCExportedInterface
+        val objCExportedInterface = context.objCExportedInterfaceProvider.objCExportedInterface
 
         val errors = listOfNotNull(
-            descriptorProvider.exposedClasses.shouldMatchExposed(objCExportedInterface.generatedClasses) { fqNameUnsafe.asString() },
-            descriptorProvider.exposedCategoryMembers.shouldMatch(objCExportedInterface.categoryMembers.values.flatten().toSet()) { fqNameUnsafe.asString() },
-            descriptorProvider.exposedTopLevelMembers.shouldMatch(objCExportedInterface.topLevel.values.flatten().toSet()) { fqNameUnsafe.asString() },
-            descriptorProvider.exposedFiles.shouldMatch(objCExportedInterface.topLevel.keys) { name ?: "<Unknown file>" },
+            context.descriptorProvider.exposedClasses.shouldMatchExposed(objCExportedInterface.generatedClasses) { fqNameUnsafe.asString() },
+            context.descriptorProvider.exposedCategoryMembers.shouldMatch(objCExportedInterface.categoryMembers.values.flatten().toSet()) { fqNameUnsafe.asString() },
+            context.descriptorProvider.exposedTopLevelMembers.shouldMatch(objCExportedInterface.topLevel.values.flatten().toSet()) { fqNameUnsafe.asString() },
+            context.descriptorProvider.exposedFiles.shouldMatch(objCExportedInterface.topLevel.keys) { name ?: "<Unknown file>" },
         )
 
         if (errors.isNotEmpty()) {
@@ -34,11 +34,11 @@ object VerifyDescriptorProviderConsistencyPhase : KirPhase {
         }
     }
 
-    context(KirPhase.Context)
+    context(context: KirPhase.Context)
     private fun Set<ClassDescriptor>.shouldMatchExposed(other: Set<ClassDescriptor>, fqName: ClassDescriptor.() -> String): String? {
         // The Kotlin compiler (incorrectly) includes non-exported classes in certain cases - for example, "internal" exceptions from Java.
         // SKIE intentionally excludes these classes, so the filter is needed before comparing the sets.
-        val exposedOther = other.filter { mapper.shouldBeExposed(it) }.toSet()
+        val exposedOther = other.filter { context.mapper.shouldBeExposed(it) }.toSet()
 
         return this.shouldMatch(exposedOther, fqName)
     }

--- a/SKIE/kotlin-compiler/linker-plugin/src/main/kotlin/co/touchlab/skie/phases/features/defaultarguments/DefaultArgumentGenerator.kt
+++ b/SKIE/kotlin-compiler/linker-plugin/src/main/kotlin/co/touchlab/skie/phases/features/defaultarguments/DefaultArgumentGenerator.kt
@@ -22,7 +22,7 @@ class DefaultArgumentGenerator(
         ::ExtensionFunctionDefaultArgumentGeneratorDelegate,
     ).map { it(context, sharedCounter) }
 
-    context(FrontendIrPhase.Context)
+    context(context: FrontendIrPhase.Context)
     override suspend fun execute() {
         delegates.forEach {
             it.generate()

--- a/SKIE/kotlin-compiler/linker-plugin/src/main/kotlin/co/touchlab/skie/phases/features/defaultarguments/delegate/BaseDefaultArgumentGeneratorDelegate.kt
+++ b/SKIE/kotlin-compiler/linker-plugin/src/main/kotlin/co/touchlab/skie/phases/features/defaultarguments/delegate/BaseDefaultArgumentGeneratorDelegate.kt
@@ -35,13 +35,13 @@ abstract class BaseDefaultArgumentGeneratorDelegate(
     private val isInteropEnabledForExternalModules: Boolean =
         SkieConfigurationFlag.Feature_DefaultArgumentsInExternalLibraries in context.globalConfiguration.enabledFlags
 
-    context(FrontendIrPhase.Context)
+    context(context: FrontendIrPhase.Context)
     protected val FunctionDescriptor.isInteropEnabled: Boolean
         get() = this.configuration[DefaultArgumentInterop.Enabled] &&
             this.satisfiesMaximumDefaultArgumentCount &&
             (descriptorProvider.isFromLocalModule(this) || isInteropEnabledForExternalModules)
 
-    context(FrontendIrPhase.Context)
+    context(context: FrontendIrPhase.Context)
     private val FunctionDescriptor.satisfiesMaximumDefaultArgumentCount: Boolean
         get() = this.defaultArgumentCount <= this.configuration[DefaultArgumentInterop.MaximumDefaultArgumentCount]
 
@@ -82,13 +82,13 @@ abstract class BaseDefaultArgumentGeneratorDelegate(
     private fun Int.testBit(n: Int): Boolean =
         (this shr n) and 1 == 1
 
-    context(IrBuilderWithScope) protected fun IrFunctionAccessExpression.passArgumentsWithMatchingNames(from: IrFunction) {
+    context(irBuilderWithScope: IrBuilderWithScope) protected fun IrFunctionAccessExpression.passArgumentsWithMatchingNames(from: IrFunction) {
         from.valueParameters.forEach { valueParameter: IrValueParameter ->
             val indexInCalledFunction = this.symbol.owner.indexOfValueParameterByName(valueParameter.name)
             check(indexInCalledFunction != -1) {
                 "Could not find value parameter with name ${valueParameter.name} in ${this.symbol.owner} (from $from)\n\nThis dump:\n${this.dump()}\n\nFrom dump:\n${from.dump()}"
             }
-            putValueArgument(indexInCalledFunction, irGet(valueParameter))
+            putValueArgument(indexInCalledFunction, irBuilderWithScope.irGet(valueParameter))
         }
     }
 

--- a/SKIE/kotlin-compiler/linker-plugin/src/main/kotlin/co/touchlab/skie/phases/features/defaultarguments/delegate/BaseFunctionDefaultArgumentGeneratorDelegate.kt
+++ b/SKIE/kotlin-compiler/linker-plugin/src/main/kotlin/co/touchlab/skie/phases/features/defaultarguments/delegate/BaseFunctionDefaultArgumentGeneratorDelegate.kt
@@ -37,13 +37,13 @@ abstract class BaseFunctionDefaultArgumentGeneratorDelegate(
     private val sharedCounter: SharedCounter,
 ) : BaseDefaultArgumentGeneratorDelegate(context) {
 
-    context(FrontendIrPhase.Context)
+    context(context: FrontendIrPhase.Context)
     override fun generate() {
         descriptorProvider.allSupportedFunctions()
             .filter { it.isInteropEnabled }
             .filterNot { it.isComposable }
             .filter { it.hasDefaultArguments }
-            .filter { mapper.isBaseMethod(it) }
+            .filter { context.mapper.isBaseMethod(it) }
             .forEach {
                 generateOverloads(it)
             }
@@ -51,14 +51,14 @@ abstract class BaseFunctionDefaultArgumentGeneratorDelegate(
 
     protected abstract fun DescriptorProvider.allSupportedFunctions(): List<SimpleFunctionDescriptor>
 
-    context(FrontendIrPhase.Context)
+    context(context: FrontendIrPhase.Context)
     private fun generateOverloads(function: SimpleFunctionDescriptor) {
         function.forEachDefaultArgumentOverload { overloadParameters ->
             generateOverload(function, overloadParameters)
         }
     }
 
-    context(FrontendIrPhase.Context)
+    context(context: FrontendIrPhase.Context)
     private fun generateOverload(
         function: SimpleFunctionDescriptor,
         parameters: List<ValueParameterDescriptor>,
@@ -70,7 +70,7 @@ abstract class BaseFunctionDefaultArgumentGeneratorDelegate(
         removeManglingOfOverload(newFunction, function)
     }
 
-    context(FrontendIrPhase.Context)
+    context(context: FrontendIrPhase.Context)
     private fun generateOverloadWithUniqueName(
         function: SimpleFunctionDescriptor,
         parameters: List<ValueParameterDescriptor>,
@@ -112,13 +112,13 @@ abstract class BaseFunctionDefaultArgumentGeneratorDelegate(
             }
         }
 
-    context(KotlinIrPhase.Context, DeclarationIrBuilder)
+    context(context: KotlinIrPhase.Context, declarationIrBuilder: DeclarationIrBuilder)
     private fun getOverloadBody(
         originalFunction: FunctionDescriptor, overloadIr: IrFunction,
     ): IrBody {
-        val originalFunctionSymbol = skieSymbolTable.descriptorExtension.referenceSimpleFunction(originalFunction)
+        val originalFunctionSymbol = context.skieSymbolTable.descriptorExtension.referenceSimpleFunction(originalFunction)
 
-        return irBlockBody {
+        return declarationIrBuilder.irBlockBody {
             +irReturn(
                 irCall(originalFunctionSymbol).apply {
                     dispatchReceiver = overloadIr.dispatchReceiverParameter?.let { irGet(it) }

--- a/SKIE/kotlin-compiler/linker-plugin/src/main/kotlin/co/touchlab/skie/phases/features/defaultarguments/delegate/ConstructorsDefaultArgumentGeneratorDelegate.kt
+++ b/SKIE/kotlin-compiler/linker-plugin/src/main/kotlin/co/touchlab/skie/phases/features/defaultarguments/delegate/ConstructorsDefaultArgumentGeneratorDelegate.kt
@@ -33,7 +33,7 @@ class ConstructorsDefaultArgumentGeneratorDelegate(
     private val sharedCounter: SharedCounter,
 ) : BaseDefaultArgumentGeneratorDelegate(context) {
 
-    context(FrontendIrPhase.Context)
+    context(context: FrontendIrPhase.Context)
     override fun generate() {
         descriptorProvider.allSupportedClasses.forEach { classDescriptor ->
             classDescriptor.allSupportedConstructors.forEach {
@@ -48,13 +48,13 @@ class ConstructorsDefaultArgumentGeneratorDelegate(
     private val ClassDescriptor.isSupported: Boolean
         get() = this.kind == ClassKind.CLASS
 
-    context(FrontendIrPhase.Context)
+    context(context: FrontendIrPhase.Context)
     private val ClassDescriptor.allSupportedConstructors: List<ClassConstructorDescriptor>
         get() = descriptorProvider.getExposedConstructors(this)
             .filter { it.isInteropEnabled }
             .filter { it.hasDefaultArguments }
 
-    context(FrontendIrPhase.Context)
+    context(context: FrontendIrPhase.Context)
     private fun generateOverloads(constructor: ClassConstructorDescriptor, classDescriptor: ClassDescriptor) {
         constructor.forEachDefaultArgumentOverload { overloadParameters ->
             if (overloadParameters.isNotEmpty() || classDescriptor.generateOverloadWithNoParameters) {
@@ -70,14 +70,14 @@ class ConstructorsDefaultArgumentGeneratorDelegate(
     private val ClassConstructorDescriptor.hasNoParametersIgnoringDefaultArguments: Boolean
         get() = this.valueParameters.count { !it.hasDefaultValue() } == 0
 
-    context(FrontendIrPhase.Context)
+    context(context: FrontendIrPhase.Context)
     private fun generateOverload(constructor: ClassConstructorDescriptor, parameters: List<ValueParameterDescriptor>) {
         val overload = generateOverloadWithUniqueName(constructor, parameters)
 
         registerOverload(overload, constructor)
     }
 
-    context(FrontendIrPhase.Context)
+    context(context: FrontendIrPhase.Context)
     private fun generateOverloadWithUniqueName(
         constructor: ClassConstructorDescriptor,
         parameters: List<ValueParameterDescriptor>,
@@ -125,13 +125,13 @@ class ConstructorsDefaultArgumentGeneratorDelegate(
     private fun String.dropUniqueParameterMangling(): String =
         this.split(uniqueNameSubstring).first()
 
-    context(KotlinIrPhase.Context, DeclarationIrBuilder)
+    context(context: KotlinIrPhase.Context, declarationIrBuilder: DeclarationIrBuilder)
     private fun getOverloadBody(
         originalConstructor: ClassConstructorDescriptor, overloadIr: IrConstructor,
     ): IrBody {
-        val originalConstructorSymbol = skieSymbolTable.descriptorExtension.referenceConstructor(originalConstructor)
+        val originalConstructorSymbol = context.skieSymbolTable.descriptorExtension.referenceConstructor(originalConstructor)
 
-        return irBlockBody {
+        return declarationIrBuilder.irBlockBody {
             +irDelegatingConstructorCall(originalConstructorSymbol.owner).apply {
                 passDispatchReceiverParameterIfPresent(overloadIr)
                 passArgumentsWithMatchingNames(overloadIr)
@@ -139,11 +139,11 @@ class ConstructorsDefaultArgumentGeneratorDelegate(
         }
     }
 
-    context(IrBuilderWithScope)
+    context(irBuilderWithScope: IrBuilderWithScope)
     private fun IrDelegatingConstructorCall.passDispatchReceiverParameterIfPresent(from: IrFunction) {
         val dispatchReceiverParameter = from.dispatchReceiverParameter ?: return
 
-        this.dispatchReceiver = irGet(dispatchReceiverParameter)
+        this.dispatchReceiver = irBuilderWithScope.irGet(dispatchReceiverParameter)
     }
 
     private fun registerOverload(overloadDescriptor: ClassConstructorDescriptor, constructor: ClassConstructorDescriptor) {

--- a/SKIE/kotlin-compiler/linker-plugin/src/main/kotlin/co/touchlab/skie/phases/features/defaultarguments/delegate/DefaultArgumentGeneratorDelegate.kt
+++ b/SKIE/kotlin-compiler/linker-plugin/src/main/kotlin/co/touchlab/skie/phases/features/defaultarguments/delegate/DefaultArgumentGeneratorDelegate.kt
@@ -4,6 +4,6 @@ import co.touchlab.skie.phases.FrontendIrPhase
 
 interface DefaultArgumentGeneratorDelegate {
 
-    context(FrontendIrPhase.Context)
+    context(context: FrontendIrPhase.Context)
     fun generate()
 }

--- a/SKIE/kotlin-compiler/linker-plugin/src/main/kotlin/co/touchlab/skie/phases/features/suspend/CheckSkieRuntimePresencePhase.kt
+++ b/SKIE/kotlin-compiler/linker-plugin/src/main/kotlin/co/touchlab/skie/phases/features/suspend/CheckSkieRuntimePresencePhase.kt
@@ -8,17 +8,17 @@ import org.jetbrains.kotlin.resolve.descriptorUtil.fqNameUnsafe
 
 object CheckSkieRuntimePresencePhase : ClassExportPhase {
 
-    context(ClassExportPhase.Context)
-    override fun isActive(): Boolean = SkieConfigurationFlag.Feature_CoroutinesInterop.isEnabled
+    context(context: ClassExportPhase.Context)
+    override fun isActive(): Boolean = context.run { SkieConfigurationFlag.Feature_CoroutinesInterop.isEnabled }
 
-    context(ClassExportPhase.Context)
+    context(context: ClassExportPhase.Context)
     override suspend fun execute() {
         val skieRuntimeClassFqName = SupportedFlow.allVariants.first().kotlinClassFqName
 
-        val isRuntimePresent = descriptorProvider.exposedClasses.any { it.fqNameUnsafe.toString() == skieRuntimeClassFqName }
+        val isRuntimePresent = context.descriptorProvider.exposedClasses.any { it.fqNameUnsafe.toString() == skieRuntimeClassFqName }
 
         if (!isRuntimePresent) {
-            SkieConfigurationFlag.Feature_CoroutinesInterop.disable()
+            context.run { SkieConfigurationFlag.Feature_CoroutinesInterop.disable() }
         }
     }
 }

--- a/SKIE/kotlin-compiler/linker-plugin/src/main/kotlin/co/touchlab/skie/phases/features/suspend/KotlinSuspendGeneratorDelegate.kt
+++ b/SKIE/kotlin-compiler/linker-plugin/src/main/kotlin/co/touchlab/skie/phases/features/suspend/KotlinSuspendGeneratorDelegate.kt
@@ -46,7 +46,7 @@ class KotlinSuspendGeneratorDelegate(
 
     private val bodyGenerator = SuspendKotlinBridgeBodyGenerator(suspendHandlerDescriptor)
 
-    context(FrontendIrPhase.Context)
+    context(context: FrontendIrPhase.Context)
     fun generateKotlinBridgingFunction(functionDescriptor: FunctionDescriptor): FunctionDescriptor {
         val bridgingFunctionDescriptor = createBridgingFunction(functionDescriptor)
 
@@ -56,7 +56,7 @@ class KotlinSuspendGeneratorDelegate(
         return bridgingFunctionDescriptor
     }
 
-    context(FrontendIrPhase.Context)
+    context(context: FrontendIrPhase.Context)
     private fun FunctionDescriptor.changeSkieConfiguration(originalFunctionDescriptor: FunctionDescriptor) {
         this.configuration.useDefaultsForSkieRuntime = true
 
@@ -153,11 +153,11 @@ class KotlinSuspendGeneratorDelegate(
         }
     }
 
-    context(KirPhase.Context)
+    context(context: KirPhase.Context)
     private fun configureFlowMappingForReceiver(
         dispatchReceiverParameter: ValueParameterDescriptor,
     ) {
-        val kirValueParameter = descriptorKirProvider.getValueParameter(dispatchReceiverParameter)
+        val kirValueParameter = context.descriptorKirProvider.getValueParameter(dispatchReceiverParameter)
 
         kirValueParameter.configuration.flowMappingStrategy = kirValueParameter.configuration.flowMappingStrategy.limitFlowMappingToTypeArguments()
     }

--- a/SKIE/kotlin-compiler/linker-plugin/src/main/kotlin/co/touchlab/skie/phases/features/suspend/SuspendGenerator.kt
+++ b/SKIE/kotlin-compiler/linker-plugin/src/main/kotlin/co/touchlab/skie/phases/features/suspend/SuspendGenerator.kt
@@ -14,22 +14,22 @@ import org.jetbrains.kotlin.descriptors.SimpleFunctionDescriptor
 
 object SuspendGenerator : FrontendIrPhase {
 
-    context(FrontendIrPhase.Context)
-    override fun isActive(): Boolean = SkieConfigurationFlag.Feature_CoroutinesInterop.isEnabled
+    context(context: FrontendIrPhase.Context)
+    override fun isActive(): Boolean = context.run { SkieConfigurationFlag.Feature_CoroutinesInterop.isEnabled }
 
-    context(FrontendIrPhase.Context)
+    context(context: FrontendIrPhase.Context)
     override suspend fun execute() {
         val kotlinDelegate = KotlinSuspendGeneratorDelegate(context)
         val swiftDelegate = SwiftSuspendGeneratorDelegate(context)
 
-        descriptorProvider.allSupportedFunctions.forEach { function ->
+        context.descriptorProvider.allSupportedFunctions.forEach { function ->
             val kotlinBridgingFunction = kotlinDelegate.generateKotlinBridgingFunction(function)
 
             swiftDelegate.generateSwiftBridgingFunction(function, kotlinBridgingFunction)
         }
     }
 
-    context(FrontendIrPhase.Context)
+    context(context: FrontendIrPhase.Context)
     private val DescriptorProvider.allSupportedFunctions: List<SimpleFunctionDescriptor>
         get() = this.allExposedMembers.filterIsInstance<SimpleFunctionDescriptor>()
             .filter { mapper.isBaseMethod(it) }

--- a/SKIE/kotlin-compiler/linker-plugin/src/main/kotlin/co/touchlab/skie/phases/features/suspend/kotlin/SuspendKotlinBridgeBodyGenerator.kt
+++ b/SKIE/kotlin-compiler/linker-plugin/src/main/kotlin/co/touchlab/skie/phases/features/suspend/kotlin/SuspendKotlinBridgeBodyGenerator.kt
@@ -19,12 +19,12 @@ class SuspendKotlinBridgeBodyGenerator(
     private val exceptionFieldGenerator = SuspendKotlinBridgeCheckedExceptionsGenerator()
     private val lambdaGenerator = SuspendKotlinBridgeHandlerLambdaGenerator()
 
-    context(KotlinIrPhase.Context, DeclarationIrBuilder)
+    context(context: KotlinIrPhase.Context, declarationIrBuilder: DeclarationIrBuilder)
     fun createBody(
         bridgingFunction: IrSimpleFunction,
         originalFunctionDescriptor: FunctionDescriptor,
     ): IrBody =
-        irBlockBody {
+        declarationIrBuilder.irBlockBody {
             val suspendHandlerParameter = bridgingFunction.valueParameters.last()
             val checkedExceptions = exceptionFieldGenerator.createGetCheckedExceptions(bridgingFunction, originalFunctionDescriptor)
             val originalFunctionCallLambda = lambdaGenerator.createOriginalFunctionCallLambda(
@@ -43,10 +43,10 @@ class SuspendKotlinBridgeBodyGenerator(
             )
         }
 
-    context(KotlinIrPhase.Context)
+    context(context: KotlinIrPhase.Context)
     private val suspendHandlerLaunchMethod: IrSimpleFunction
         get() {
-            val suspendHandlerClass = skieSymbolTable.descriptorExtension.referenceClass(suspendHandlerDescriptor).owner
+            val suspendHandlerClass = context.skieSymbolTable.descriptorExtension.referenceClass(suspendHandlerDescriptor).owner
 
             return suspendHandlerClass.declarations
                 .filterIsInstance<IrSimpleFunction>()

--- a/SKIE/kotlin-compiler/linker-plugin/src/main/kotlin/co/touchlab/skie/phases/features/suspend/kotlin/SuspendKotlinBridgeCheckedExceptionsGenerator.kt
+++ b/SKIE/kotlin-compiler/linker-plugin/src/main/kotlin/co/touchlab/skie/phases/features/suspend/kotlin/SuspendKotlinBridgeCheckedExceptionsGenerator.kt
@@ -40,30 +40,30 @@ import org.jetbrains.kotlin.types.KotlinType
 
 class SuspendKotlinBridgeCheckedExceptionsGenerator {
 
-    context(KotlinIrPhase.Context, DeclarationIrBuilder)
+    context(context: KotlinIrPhase.Context, declarationIrBuilder: DeclarationIrBuilder)
     fun createGetCheckedExceptions(
         bridgingFunction: IrSimpleFunction,
         originalFunctionDescriptor: FunctionDescriptor,
     ): IrExpression {
         val field = createCheckedExceptionsField(bridgingFunction, originalFunctionDescriptor)
 
-        return irGetField(null, field)
+        return declarationIrBuilder.irGetField(null, field)
     }
 
-    context(KotlinIrPhase.Context)
+    context(context: KotlinIrPhase.Context)
     private fun createCheckedExceptionsField(
         bridgingFunction: IrSimpleFunction,
         originalFunctionDescriptor: FunctionDescriptor,
     ): IrField {
         val fieldSymbol = IrFieldSymbolImpl()
 
-        val field = irFactory.createField(
+        val field = context.irFactory.createField(
             startOffset = 0,
             endOffset = 0,
             origin = SUSPEND_WRAPPER_CHECKED_EXCEPTIONS,
             symbol = fieldSymbol,
             name = Name.identifier(bridgingFunction.nameForCheckedExceptionsField),
-            type = irBuiltIns.arrayClass.typeWith(irBuiltIns.kClassClass.typeWith(irBuiltIns.throwableType)),
+            type = context.irBuiltIns.arrayClass.typeWith(context.irBuiltIns.kClassClass.typeWith(context.irBuiltIns.throwableType)),
             visibility = DescriptorVisibilities.PRIVATE,
             isFinal = true,
             isExternal = false,
@@ -84,17 +84,17 @@ class SuspendKotlinBridgeCheckedExceptionsGenerator {
     private val IrSimpleFunction.nameForCheckedExceptionsField: String
         get() = this.name.identifier + "__checkedExceptions"
 
-    context(KotlinIrPhase.Context)
+    context(context: KotlinIrPhase.Context)
     private fun createCheckExceptionsFieldInitializer(
         fieldSymbol: IrFieldSymbolImpl,
         originalFunctionDescriptor: FunctionDescriptor,
     ): IrExpressionBody =
-        DeclarationIrBuilder(pluginContext.generatorContext, fieldSymbol, 0, 0).run {
+        DeclarationIrBuilder(context.pluginContext.generatorContext, fieldSymbol, 0, 0).run {
             irExprBody(
-                irCall(irBuiltIns.arrayOf).apply {
+                irCall(context.irBuiltIns.arrayOf).apply {
                     val checkedExceptionClassReferences = createCheckedExceptionClassReferences(originalFunctionDescriptor)
 
-                    val varargElementType = irBuiltIns.kClassClass.typeWith(irBuiltIns.throwableType)
+                    val varargElementType = context.irBuiltIns.kClassClass.typeWith(context.irBuiltIns.throwableType)
                     val vararg = irVararg(varargElementType, checkedExceptionClassReferences)
 
                     putTypeArgument(0, varargElementType)
@@ -103,7 +103,7 @@ class SuspendKotlinBridgeCheckedExceptionsGenerator {
             )
         }
 
-    context(KotlinIrPhase.Context)
+    context(context: KotlinIrPhase.Context)
     private fun createCheckedExceptionClassReferences(
         originalFunctionDescriptor: FunctionDescriptor,
     ): List<IrClassReference> =
@@ -112,13 +112,13 @@ class SuspendKotlinBridgeCheckedExceptionsGenerator {
                 IrClassReferenceImpl(
                     startOffset = 0,
                     endOffset = 0,
-                    type = irBuiltIns.kClassClass.typeWith(exceptionTypeSymbol.defaultType),
+                    type = context.irBuiltIns.kClassClass.typeWith(exceptionTypeSymbol.defaultType),
                     symbol = exceptionTypeSymbol,
                     classType = exceptionTypeSymbol.defaultType,
                 )
             }
 
-    context(KotlinIrPhase.Context)
+    context(context: KotlinIrPhase.Context)
     private val FunctionDescriptor.declaredThrownExceptions: List<IrClassifierSymbol>
         get() {
             val throwsAnnotation = this.annotations.findAnnotation(KonanFqNames.throws) ?: return emptyList()
@@ -129,19 +129,19 @@ class SuspendKotlinBridgeCheckedExceptionsGenerator {
             return exceptionClasses.map { it.getClassifierSymbol(this.module) }
         }
 
-    context(KotlinIrPhase.Context)
+    context(context: KotlinIrPhase.Context)
     private fun KClassValue.getClassifierSymbol(module: ModuleDescriptor): IrClassifierSymbol =
         when (val value = this.value) {
             is Value.LocalClass -> value.type.toIrSymbol()
             is Value.NormalClass -> module.findClassifierAcrossModuleDependencies(value.classId)!!.defaultType.toIrSymbol()
         }
 
-    context(KotlinIrPhase.Context)
+    context(context: KotlinIrPhase.Context)
     private fun KotlinType.toIrSymbol(): IrClassifierSymbol =
         when (val classifier = this.constructor.declarationDescriptor) {
             null -> error("No declaration descriptor for type $this.")
             is TypeAliasDescriptor -> classifier.expandedType.toIrSymbol()
-            else -> skieSymbolTable.kotlinSymbolTable.referenceClassifier(classifier)
+            else -> context.skieSymbolTable.kotlinSymbolTable.referenceClassifier(classifier)
         }
 
     companion object {

--- a/SKIE/kotlin-compiler/linker-plugin/src/main/kotlin/co/touchlab/skie/phases/features/suspend/kotlin/SuspendKotlinBridgeHandlerLambdaGenerator.kt
+++ b/SKIE/kotlin-compiler/linker-plugin/src/main/kotlin/co/touchlab/skie/phases/features/suspend/kotlin/SuspendKotlinBridgeHandlerLambdaGenerator.kt
@@ -27,39 +27,39 @@ import org.jetbrains.kotlin.name.SpecialNames
 
 class SuspendKotlinBridgeHandlerLambdaGenerator {
 
-    context(KotlinIrPhase.Context, IrBlockBodyBuilder)
+    context(context: KotlinIrPhase.Context, irBlockBodyBuilder: IrBlockBodyBuilder)
     fun createOriginalFunctionCallLambda(
         bridgingFunction: IrSimpleFunction,
         originalFunctionDescriptor: FunctionDescriptor,
         type: IrType,
     ): IrFunctionExpression =
-        irFunctionExpression(
+        irBlockBodyBuilder.irFunctionExpression(
             type = type,
             origin = IrStatementOrigin.LAMBDA,
             function = createOriginalFunctionCallLambdaFunction(bridgingFunction, originalFunctionDescriptor),
         )
 
-    context(KotlinIrPhase.Context, IrBlockBodyBuilder)
+    context(context: KotlinIrPhase.Context, irBlockBodyBuilder: IrBlockBodyBuilder)
     private fun createOriginalFunctionCallLambdaFunction(
         bridgingFunction: IrSimpleFunction,
         originalFunctionDescriptor: FunctionDescriptor,
     ): IrSimpleFunction =
-        irSimpleFunction(
+        irBlockBodyBuilder.irSimpleFunction(
             name = SpecialNames.ANONYMOUS,
             visibility = DescriptorVisibilities.LOCAL,
-            returnType = irBuiltIns.anyType.makeNullable(),
+            returnType = context.irBuiltIns.anyType.makeNullable(),
             origin = IrDeclarationOrigin.LOCAL_FUNCTION_FOR_LAMBDA,
             isSuspend = true,
             body = { createOriginalFunctionCallLambdaFunctionBody(bridgingFunction, originalFunctionDescriptor) },
         )
 
-    context(KotlinIrPhase.Context, DeclarationIrBuilder)
+    context(context: KotlinIrPhase.Context, declarationIrBuilder: DeclarationIrBuilder)
     private fun createOriginalFunctionCallLambdaFunctionBody(
         bridgingFunction: IrSimpleFunction,
         originalFunctionDescriptor: FunctionDescriptor,
     ): IrBlockBody =
-        irBlockBody {
-            val originalFunctionSymbol = skieSymbolTable.descriptorExtension.referenceSimpleFunction(originalFunctionDescriptor)
+        declarationIrBuilder.irBlockBody {
+            val originalFunctionSymbol = context.skieSymbolTable.descriptorExtension.referenceSimpleFunction(originalFunctionDescriptor)
 
             +irReturn(
                 irCall(originalFunctionSymbol).apply {
@@ -71,7 +71,7 @@ class SuspendKotlinBridgeHandlerLambdaGenerator {
             )
         }
 
-    context(DeclarationIrBuilder)
+    context(declarationIrBuilder: DeclarationIrBuilder)
     private fun IrCall.setDispatchReceiverForDelegatingCall(
         bridgingFunction: IrSimpleFunction,
         originalFunctionDescriptor: FunctionDescriptor,
@@ -79,11 +79,11 @@ class SuspendKotlinBridgeHandlerLambdaGenerator {
         if (originalFunctionDescriptor.dispatchReceiverParameter != null) {
             val dispatchReceiverParameter = bridgingFunction.valueParameters.first()
 
-            dispatchReceiver = irGet(dispatchReceiverParameter)
+            dispatchReceiver = declarationIrBuilder.irGet(dispatchReceiverParameter)
         }
     }
 
-    context(DeclarationIrBuilder)
+    context(declarationIrBuilder: DeclarationIrBuilder)
     private fun IrCall.setExtensionReceiverForDelegatingCall(
         bridgingFunction: IrSimpleFunction,
         originalFunctionDescriptor: FunctionDescriptor,
@@ -93,17 +93,17 @@ class SuspendKotlinBridgeHandlerLambdaGenerator {
 
             val extensionReceiverParameter = bridgingFunction.valueParameters[parameterIndex]
 
-            extensionReceiver = irGet(extensionReceiverParameter)
+            extensionReceiver = declarationIrBuilder.irGet(extensionReceiverParameter)
         }
     }
 
-    context(DeclarationIrBuilder)
+    context(declarationIrBuilder: DeclarationIrBuilder)
     private fun IrCall.setValueArgumentsForDelegatingCall(
         bridgingFunction: IrSimpleFunction,
         originalFunctionDescriptor: FunctionDescriptor,
     ) {
         val valueParameters = bridgingFunction.filterRealValueParameters(originalFunctionDescriptor)
-        val valueArguments = valueParameters.map { irGet(it) }
+        val valueArguments = valueParameters.map { declarationIrBuilder.irGet(it) }
 
         valueArguments.forEachIndexed { index, argument ->
             putValueArgument(index, argument)

--- a/SKIE/kotlin-compiler/linker-plugin/src/main/kotlin/co/touchlab/skie/phases/kir/BaseCreateRegularKirFunctionPhase.kt
+++ b/SKIE/kotlin-compiler/linker-plugin/src/main/kotlin/co/touchlab/skie/phases/kir/BaseCreateRegularKirFunctionPhase.kt
@@ -27,7 +27,7 @@ internal abstract class BaseCreateRegularKirFunctionPhase(
     supportsSimpleFunctions = supportsSimpleFunctions,
 ) {
 
-    context(KirTypeParameterScope)
+    context(kirTypeParameterScope: KirTypeParameterScope)
     protected fun createValueParameters(
         function: KirFunction<*>,
         descriptor: FunctionDescriptor,
@@ -39,7 +39,7 @@ internal abstract class BaseCreateRegularKirFunctionPhase(
             }
     }
 
-    context(KirTypeParameterScope)
+    context(kirTypeParameterScope: KirTypeParameterScope)
     private fun createValueParameter(
         parameterBridge: MethodBridgeValueParameter,
         parameterDescriptor: ParameterDescriptor?,

--- a/SKIE/kotlin-compiler/linker-plugin/src/main/kotlin/co/touchlab/skie/phases/kir/BaseCreateRegularKirMembersPhase.kt
+++ b/SKIE/kotlin-compiler/linker-plugin/src/main/kotlin/co/touchlab/skie/phases/kir/BaseCreateRegularKirMembersPhase.kt
@@ -18,7 +18,7 @@ internal abstract class BaseCreateRegularKirMembersPhase(
     private val supportsProperties: Boolean = false,
 ) : BaseCreateKirMembersPhase(context) {
 
-    context(KirPhase.Context)
+    context(context: KirPhase.Context)
     override suspend fun execute() {
         kirProvider.kotlinClasses.forEach(::createMembers)
     }

--- a/SKIE/kotlin-compiler/linker-plugin/src/main/kotlin/co/touchlab/skie/phases/kir/CreateExposedKirTypesPhase.kt
+++ b/SKIE/kotlin-compiler/linker-plugin/src/main/kotlin/co/touchlab/skie/phases/kir/CreateExposedKirTypesPhase.kt
@@ -54,7 +54,7 @@ class CreateExposedKirTypesPhase(
         ),
     )
 
-    context(KirPhase.Context)
+    context(context: KirPhase.Context)
     override suspend fun execute() {
         createRegularClasses()
         createFileClasses()
@@ -213,7 +213,7 @@ class CreateExposedKirTypesPhase(
 
     companion object {
 
-        context(DescriptorKirProvider)
+        context(descriptorKirProvider: DescriptorKirProvider)
         fun createTypeParameters(kirClass: KirClass, descriptor: ClassDescriptor, namer: ObjCExportNamer) {
             if (kirClass.kind != KirClass.Kind.Class) {
                 return
@@ -224,7 +224,7 @@ class CreateExposedKirTypesPhase(
             }
         }
 
-        context(DescriptorKirProvider)
+        context(descriptorKirProvider: DescriptorKirProvider)
         private fun createTypeParameter(
             kirClass: KirClass,
             typeParameterDescriptor: TypeParameterDescriptor,
@@ -241,7 +241,7 @@ class CreateExposedKirTypesPhase(
                 // Bounds are not supported.
             )
 
-            this@DescriptorKirProvider.registerTypeParameter(typeParameter, typeParameterDescriptor)
+            descriptorKirProvider.registerTypeParameter(typeParameter, typeParameterDescriptor)
         }
 
         fun getNestingLevel(classDescriptor: ClassDescriptor): Int =

--- a/SKIE/kotlin-compiler/linker-plugin/src/main/kotlin/co/touchlab/skie/phases/kir/CreateKirDescriptionAndHashPropertyPhase.kt
+++ b/SKIE/kotlin-compiler/linker-plugin/src/main/kotlin/co/touchlab/skie/phases/kir/CreateKirDescriptionAndHashPropertyPhase.kt
@@ -24,7 +24,7 @@ internal class CreateKirDescriptionAndHashPropertyPhase(
     context: KirPhase.Context,
 ) : BaseCreateKirMembersPhase(context) {
 
-    context(KirPhase.Context)
+    context(context: KirPhase.Context)
     override fun isActive(): Boolean =
     // TODO Change back once we generate custom header
         // TODO Add tests for this flag and functionality
@@ -33,14 +33,14 @@ internal class CreateKirDescriptionAndHashPropertyPhase(
 
     private val cache = mutableMapOf<FunctionDescriptor, KirProperty>()
 
-    context(KirPhase.Context)
+    context(context: KirPhase.Context)
     override suspend fun execute() {
         kirProvider.kotlinClasses.forEach {
             createDescriptionProperty(it)
         }
     }
 
-    context(KirPhase.Context)
+    context(context: KirPhase.Context)
     private fun createDescriptionProperty(kirClass: KirClass) {
         if (kirClass in kirProvider.kirBuiltins.builtinClasses) {
             // TODO Implement accurate way to generate builtin members once needed
@@ -50,7 +50,7 @@ internal class CreateKirDescriptionAndHashPropertyPhase(
         val classDescriptor = descriptorKirProvider.findClassDescriptor(kirClass) ?: return
 
         classDescriptor.findSpecialFunction(OperatorNameConventions.TO_STRING)?.let {
-            getOrCreateProperty(it, kirClass, kirBuiltins.NSString.defaultType)
+            getOrCreateProperty(it, kirClass, kirProvider.kirBuiltins.NSString.defaultType)
         }
 
         classDescriptor.findSpecialFunction(OperatorNameConventions.HASH_CODE)?.let {

--- a/SKIE/kotlin-compiler/linker-plugin/src/main/kotlin/co/touchlab/skie/phases/kir/CreateKirSimpleFunctionsPhase.kt
+++ b/SKIE/kotlin-compiler/linker-plugin/src/main/kotlin/co/touchlab/skie/phases/kir/CreateKirSimpleFunctionsPhase.kt
@@ -27,7 +27,7 @@ internal class CreateKirSimpleFunctionsPhase(
 //     private val needsDescriptionAndHashFunctions = SkieConfigurationFlag.Migration_AnyMethodsAsFunctions in context.globalConfiguration.enabledFlags
     private val needsDescriptionAndHashFunctions = true
 
-    context(KirPhase.Context)
+    context(context: KirPhase.Context)
     override suspend fun execute() {
         super.execute()
 

--- a/SKIE/kotlin-compiler/linker-plugin/src/main/kotlin/co/touchlab/skie/phases/other/ConfigureSwiftSpecificLinkerArgsPhase.kt
+++ b/SKIE/kotlin-compiler/linker-plugin/src/main/kotlin/co/touchlab/skie/phases/other/ConfigureSwiftSpecificLinkerArgsPhase.kt
@@ -9,21 +9,21 @@ import java.io.File
 
 object ConfigureSwiftSpecificLinkerArgsPhase : LinkPhase {
 
-    context(LinkPhase.Context)
+    context(context: LinkPhase.Context)
     override suspend fun execute() {
         val swiftLibSearchPaths = listOf(
             File(
-                configurables.absoluteTargetToolchain,
-                "lib/swift/${configurables.platformName().lowercase()}",
+                context.configurables.absoluteTargetToolchain,
+                "lib/swift/${context.configurables.platformName().lowercase()}",
             ),
-            File(configurables.absoluteTargetSysRoot, "usr/lib/swift"),
+            File(context.configurables.absoluteTargetSysRoot, "usr/lib/swift"),
         ).flatMap { listOf("-L", it.absolutePath) }
 
         val otherLinkerFlags = listOf(
             "-rpath", "/usr/lib/swift", "-dead_strip",
         )
 
-        konanConfig.configuration.addAll(KonanConfigKeys.LINKER_ARGS, swiftLibSearchPaths)
-        konanConfig.configuration.addAll(KonanConfigKeys.LINKER_ARGS, otherLinkerFlags)
+        context.konanConfig.configuration.addAll(KonanConfigKeys.LINKER_ARGS, swiftLibSearchPaths)
+        context.konanConfig.configuration.addAll(KonanConfigKeys.LINKER_ARGS, otherLinkerFlags)
     }
 }

--- a/SKIE/kotlin-compiler/linker-plugin/src/main/kotlin/co/touchlab/skie/phases/other/DeclareMissingSymbolsPhase.kt
+++ b/SKIE/kotlin-compiler/linker-plugin/src/main/kotlin/co/touchlab/skie/phases/other/DeclareMissingSymbolsPhase.kt
@@ -5,8 +5,8 @@ import co.touchlab.skie.phases.declarationBuilder
 
 object DeclareMissingSymbolsPhase : SymbolTablePhase {
 
-    context(SymbolTablePhase.Context)
+    context(context: SymbolTablePhase.Context)
     override suspend fun execute() {
-        declarationBuilder.declareSymbols()
+        context.declarationBuilder.declareSymbols()
     }
 }

--- a/SKIE/kotlin-compiler/linker-plugin/src/main/kotlin/co/touchlab/skie/phases/other/ExtraClassExportPhase.kt
+++ b/SKIE/kotlin-compiler/linker-plugin/src/main/kotlin/co/touchlab/skie/phases/other/ExtraClassExportPhase.kt
@@ -38,7 +38,7 @@ class ExtraClassExportPhase(
     private val descriptorProvider = context.descriptorProvider
     private val mapper = context.mapper
 
-    context(ClassExportPhase.Context)
+    context(context: ClassExportPhase.Context)
     override suspend fun execute() {
         val previouslyVisitedClasses = mutableSetOf<ClassDescriptor>()
 
@@ -59,7 +59,7 @@ class ExtraClassExportPhase(
         } while (newlyDiscoveredClasses.isNotEmpty())
     }
 
-    context(ClassExportPhase.Context)
+    context(context: ClassExportPhase.Context)
     private fun getClassesForExport(previouslyVisitedClasses: Set<ClassDescriptor>): Set<ClassDescriptor> {
         val result = getClassesForExportFromFlowArguments(previouslyVisitedClasses) +
             getClassesForExportFromSealedHierarchies(previouslyVisitedClasses)
@@ -67,9 +67,9 @@ class ExtraClassExportPhase(
         return result.toSet()
     }
 
-    context(ClassExportPhase.Context)
+    context(context: ClassExportPhase.Context)
     private fun getClassesForExportFromFlowArguments(previouslyVisitedClasses: Set<ClassDescriptor>): List<ClassDescriptor> {
-        if (SkieConfigurationFlag.Feature_CoroutinesInterop.isDisabled) {
+        if (context.run { SkieConfigurationFlag.Feature_CoroutinesInterop.isDisabled }) {
             return emptyList()
         }
 
@@ -96,14 +96,14 @@ class ExtraClassExportPhase(
         declaredTypeParameters.flatMap { it.getAllFlowArgumentClasses() } +
             descriptorProvider.getAllExposedMembers(this).flatMap { it.getAllFlowArgumentClasses() }
 
-    context(ClassExportPhase.Context)
+    context(context: ClassExportPhase.Context)
     private fun getClassesForExportFromSealedHierarchies(previouslyVisitedClasses: Set<ClassDescriptor>): List<ClassDescriptor> {
         val newClasses = descriptorProvider.exposedClasses - previouslyVisitedClasses
 
         return newClasses.flatMap { it.getAllExportedSealedChildren() }
     }
 
-    context(ClassExportPhase.Context)
+    context(context: ClassExportPhase.Context)
     private fun ClassDescriptor.getAllExportedSealedChildren(): List<ClassDescriptor> {
         if (!this.configuration[SealedInterop.ExportEntireHierarchy]) {
             return emptyList()
@@ -114,11 +114,11 @@ class ExtraClassExportPhase(
         return topLevelSealedChildren + topLevelSealedChildren.getAllExportedSealedChildren()
     }
 
-    context(ClassExportPhase.Context)
+    context(context: ClassExportPhase.Context)
     private fun Collection<ClassDescriptor>.getAllExportedSealedChildren(): List<ClassDescriptor> =
         this.flatMap { it.getAllExportedSealedChildren() }
 
-    context(ClassExportPhase.Context)
+    context(context: ClassExportPhase.Context)
     private fun exportClasses(classes: Set<ClassDescriptor>, iteration: Int) {
         if (classes.isEmpty()) {
             return

--- a/SKIE/kotlin-compiler/linker-plugin/src/main/kotlin/co/touchlab/skie/phases/other/FixLibrariesShortNamePhase.kt
+++ b/SKIE/kotlin-compiler/linker-plugin/src/main/kotlin/co/touchlab/skie/phases/other/FixLibrariesShortNamePhase.kt
@@ -9,9 +9,9 @@ import org.jetbrains.kotlin.library.uniqueName
 // Fix for some libraries having ":" in their short name which resulted in invalid Obj-C header
 object FixLibrariesShortNamePhase : ClassExportPhase {
 
-    context(ClassExportPhase.Context)
+    context(context: ClassExportPhase.Context)
     override suspend fun execute() {
-        descriptorProvider.resolvedLibraries.forEach { library ->
+        context.descriptorProvider.resolvedLibraries.forEach { library ->
             if (library.shortName == null) {
                 library.manifestProperties.setProperty(
                     KLIB_PROPERTY_SHORT_NAME,

--- a/SKIE/kotlin-compiler/linker-plugin/src/main/kotlin/co/touchlab/skie/phases/other/GenerateIrPhase.kt
+++ b/SKIE/kotlin-compiler/linker-plugin/src/main/kotlin/co/touchlab/skie/phases/other/GenerateIrPhase.kt
@@ -5,8 +5,8 @@ import co.touchlab.skie.phases.declarationBuilder
 
 object GenerateIrPhase : KotlinIrPhase {
 
-    context(KotlinIrPhase.Context)
+    context(context: KotlinIrPhase.Context)
     override suspend fun execute() {
-        declarationBuilder.generateIr()
+        context.declarationBuilder.generateIr()
     }
 }

--- a/SKIE/kotlin-compiler/linker-plugin/src/main/kotlin/co/touchlab/skie/phases/other/ProcessReportedMessagesPhase.kt
+++ b/SKIE/kotlin-compiler/linker-plugin/src/main/kotlin/co/touchlab/skie/phases/other/ProcessReportedMessagesPhase.kt
@@ -16,28 +16,28 @@ import org.jetbrains.kotlin.resolve.descriptorUtil.module
 
 object ProcessReportedMessagesPhase : LinkPhase {
 
-    context(LinkPhase.Context)
+    context(context: LinkPhase.Context)
     override suspend fun execute() {
-        kirReporter.reportAll(descriptorKirProvider::findDeclarationDescriptor)
+        context.kirReporter.reportAll(context.descriptorKirProvider::findDeclarationDescriptor)
 
-        descriptorReporter.reportAll { it }
+        context.descriptorReporter.reportAll { it }
     }
 
-    context(LinkPhase.Context)
+    context(context: LinkPhase.Context)
     private fun <T> Reporter<T>.reportAll(findDeclarationDescriptor: (T) -> DeclarationDescriptor?) {
         this.reports.forEach {
             report(it, findDeclarationDescriptor)
         }
     }
 
-    context(LinkPhase.Context)
+    context(context: LinkPhase.Context)
     private fun <T> report(report: Reporter.Report<T>, findDeclarationDescriptor: (T) -> DeclarationDescriptor?) {
         val declarationDescriptor = report.source?.let { findDeclarationDescriptor(it) }
 
         report(report, declarationDescriptor)
     }
 
-    context(LinkPhase.Context)
+    context(context: LinkPhase.Context)
     private fun <T> report(report: Reporter.Report<T>, declaration: DeclarationDescriptor?) {
         val location = MessageUtil.psiElementToMessageLocation(declaration?.findPsi())?.let {
             CompilerMessageLocation.create(it.path, it.line, it.column, it.lineContent)
@@ -50,8 +50,8 @@ object ProcessReportedMessagesPhase : LinkPhase {
         }
 
         when (report.severity) {
-            Reporter.Severity.Error -> konanConfig.configuration.report(CompilerMessageSeverity.ERROR, message, location)
-            Reporter.Severity.Warning -> konanConfig.configuration.report(CompilerMessageSeverity.WARNING, message, location)
+            Reporter.Severity.Error -> context.konanConfig.configuration.report(CompilerMessageSeverity.ERROR, message, location)
+            Reporter.Severity.Warning -> context.konanConfig.configuration.report(CompilerMessageSeverity.WARNING, message, location)
         }
     }
 }

--- a/SKIE/kotlin-compiler/linker-plugin/src/main/kotlin/co/touchlab/skie/phases/other/ValidateSkieVisibilityAnnotationsPhase.kt
+++ b/SKIE/kotlin-compiler/linker-plugin/src/main/kotlin/co/touchlab/skie/phases/other/ValidateSkieVisibilityAnnotationsPhase.kt
@@ -9,25 +9,25 @@ import org.jetbrains.kotlin.descriptors.DeclarationDescriptor
 
 object ValidateSkieVisibilityAnnotationsPhase : ClassExportPhase {
 
-    context(ClassExportPhase.Context)
+    context(context: ClassExportPhase.Context)
     override suspend fun execute() {
-        descriptorProvider.allExposedMembers.forEach {
+        context.descriptorProvider.allExposedMembers.forEach {
             validate(it)
         }
 
-        descriptorProvider.exposedClasses.forEach {
+        context.descriptorProvider.exposedClasses.forEach {
             validate(it)
         }
     }
 
-    context(ClassExportPhase.Context)
+    context(context: ClassExportPhase.Context)
     private fun validate(declarationDescriptor: DeclarationDescriptor) {
         val visibilityAnnotations = declarationDescriptor.annotations.filter {
             it.fqName?.asString()?.startsWith(SkieVisibility::class.qualifiedName!!) == true
         }
 
         if (visibilityAnnotations.size > 1) {
-            descriptorReporter.warning(
+            context.descriptorReporter.warning(
                 "Multiple ${SkieVisibility::class.simpleName} annotations used simultaneously. This is not allowed and may result in undefined behavior. " +
                     "This warning might become an error in the future.",
                 declarationDescriptor,

--- a/SKIE/kotlin-compiler/linker-plugin/src/main/kotlin/co/touchlab/skie/phases/other/VerifyMinOSVersionPhase.kt
+++ b/SKIE/kotlin-compiler/linker-plugin/src/main/kotlin/co/touchlab/skie/phases/other/VerifyMinOSVersionPhase.kt
@@ -8,17 +8,17 @@ import co.touchlab.skie.util.version.isLowerVersionThan
 
 object VerifyMinOSVersionPhase : ClassExportPhase {
 
-    context(ClassExportPhase.Context)
-    override fun isActive(): Boolean = SkieConfigurationFlag.Feature_CoroutinesInterop.isEnabled
+    context(context: ClassExportPhase.Context)
+    override fun isActive(): Boolean = context.run { SkieConfigurationFlag.Feature_CoroutinesInterop.isEnabled }
 
-    context(ClassExportPhase.Context)
+    context(context: ClassExportPhase.Context)
     override suspend fun execute() {
-        val currentMinVersion = configurables.osVersionMin
-        val minRequiredVersion = getMinRequiredOsVersionForSwiftAsync(configurables.target.name)
+        val currentMinVersion = context.configurables.osVersionMin
+        val minRequiredVersion = getMinRequiredOsVersionForSwiftAsync(context.configurables.target.name)
 
         if (currentMinVersion.isLowerVersionThan(minRequiredVersion)) {
             error(
-                "Minimum OS version for ${configurables.target.name} must be at least $minRequiredVersion to support Swift Async. " +
+                "Minimum OS version for ${context.configurables.target.name} must be at least $minRequiredVersion to support Swift Async. " +
                     "However, the configured minimum OS version is only $currentMinVersion. " +
                     "This is most likely a bug in SKIE Gradle plugin which should have set the minimum required version automatically.",
             )

--- a/build-setup/src/main/kotlin/co/touchlab/skie/buildsetup/main/plugins/utility/UtilityExperimentalContextReceiversPlugin.kt
+++ b/build-setup/src/main/kotlin/co/touchlab/skie/buildsetup/main/plugins/utility/UtilityExperimentalContextReceiversPlugin.kt
@@ -13,16 +13,10 @@ abstract class UtilityExperimentalContextReceiversPlugin : Plugin<Project> {
     override fun apply(target: Project): Unit = with(target) {
         plugins.withType<KotlinBasePluginWrapper>().configureEach {
             extensions.configure<KotlinBaseExtension> {
-                sourceSets.configureEach {
-                    languageSettings {
-                        enableLanguageFeature("ContextReceivers")
-                    }
-                }
-
                 if (this is HasConfigurableKotlinCompilerOptions<*>) {
                     compilerOptions {
                         freeCompilerArgs.addAll(
-                            "-Xwarning-level=CONTEXT_RECEIVERS_DEPRECATED:disabled",
+                            "-Xcontext-parameters",
                         )
                     }
                 }

--- a/common-gradle/gradle/libs.versions.toml
+++ b/common-gradle/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 [versions]
 jvmTarget = "11"
 jvmToolchain = "21"
-kotlin = "2.2.20"
+kotlin = "2.3.20"
 pluginPublish = "2.0.0"
 kotest = "6.0.4"
 buildconfig = "5.7.0"


### PR DESCRIPTION
Kotlin 2.3.20 removed context receivers (CONTEXT_RECEIVERS_DEPRECATED is now a hard error and can no longer be downgraded), so compiling SKIE's own sources with the 2.3.20 compiler requires migrating off them. This bumps the build Kotlin version in libs.versions.toml from 2.2.20 to 2.3.20.

Migrates 163 files (kotlin-compiler core/linker-plugin and acceptance-tests) from context(T) receivers to named context(context: T) parameters, qualifying the previously-implicit context-member accesses (e.g. context.sirProvider) and replacing this@Context labels. The build plugin switches from enableLanguageFeature("ContextReceivers") + -Xwarning-level=CONTEXT_RECEIVERS_DEPRECATED:disabled to -Xcontext-parameters.

All linker-plugin variants (2.0.0 through 2.3.20) are compiled by the KGP-bundled 2.3.20 compiler and still build, so SKIE's multi-version target support is unchanged.