### PR TITLE
Allowing to enable animations within Observing and Collect into

### DIFF
--- a/SKIE/acceptance-tests/functional/src/test/resources/tests/coroutines/flow/swiftui/collect/animation/collect_into_default_animation/A.kt
+++ b/SKIE/acceptance-tests/functional/src/test/resources/tests/coroutines/flow/swiftui/collect/animation/collect_into_default_animation/A.kt
@@ -1,0 +1,6 @@
+package `tests`.`coroutines`.`flow`.`swiftui`.`collect`.`animation`.`collect_into_default_animation`
+
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+
+val counter: StateFlow<Int> = MutableStateFlow(0)

--- a/SKIE/acceptance-tests/functional/src/test/resources/tests/coroutines/flow/swiftui/collect/animation/collect_into_default_animation/_.swift
+++ b/SKIE/acceptance-tests/functional/src/test/resources/tests/coroutines/flow/swiftui/collect/animation/collect_into_default_animation/_.swift
@@ -1,0 +1,13 @@
+import SwiftUI
+
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
+struct TestView: View {
+    @State var value: KotlinInt = KotlinInt(0)
+
+    var body: some View {
+        Text("")
+            .collect(flow: AKt.counter, into: $value, animation: .default)
+    }
+}
+
+exit(0)

--- a/SKIE/acceptance-tests/functional/src/test/resources/tests/coroutines/flow/swiftui/collect/animation/collect_into_nil_animation/A.kt
+++ b/SKIE/acceptance-tests/functional/src/test/resources/tests/coroutines/flow/swiftui/collect/animation/collect_into_nil_animation/A.kt
@@ -1,0 +1,6 @@
+package `tests`.`coroutines`.`flow`.`swiftui`.`collect`.`animation`.`collect_into_nil_animation`
+
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+
+val counter: StateFlow<Int> = MutableStateFlow(0)

--- a/SKIE/acceptance-tests/functional/src/test/resources/tests/coroutines/flow/swiftui/collect/animation/collect_into_nil_animation/_.swift
+++ b/SKIE/acceptance-tests/functional/src/test/resources/tests/coroutines/flow/swiftui/collect/animation/collect_into_nil_animation/_.swift
@@ -1,0 +1,13 @@
+import SwiftUI
+
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
+struct TestView: View {
+    @State var value: KotlinInt = KotlinInt(0)
+
+    var body: some View {
+        Text("")
+            .collect(flow: AKt.counter, into: $value, animation: nil)
+    }
+}
+
+exit(0)

--- a/SKIE/acceptance-tests/functional/src/test/resources/tests/coroutines/flow/swiftui/collect/animation/collect_into_no_animation/A.kt
+++ b/SKIE/acceptance-tests/functional/src/test/resources/tests/coroutines/flow/swiftui/collect/animation/collect_into_no_animation/A.kt
@@ -1,0 +1,6 @@
+package `tests`.`coroutines`.`flow`.`swiftui`.`collect`.`animation`.`collect_into_no_animation`
+
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+
+val counter: StateFlow<Int> = MutableStateFlow(0)

--- a/SKIE/acceptance-tests/functional/src/test/resources/tests/coroutines/flow/swiftui/collect/animation/collect_into_no_animation/_.swift
+++ b/SKIE/acceptance-tests/functional/src/test/resources/tests/coroutines/flow/swiftui/collect/animation/collect_into_no_animation/_.swift
@@ -1,0 +1,13 @@
+import SwiftUI
+
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
+struct TestView: View {
+    @State var value: KotlinInt = KotlinInt(0)
+
+    var body: some View {
+        Text("")
+            .collect(flow: AKt.counter, into: $value)
+    }
+}
+
+exit(0)

--- a/SKIE/acceptance-tests/functional/src/test/resources/tests/coroutines/flow/swiftui/collect/animation/collect_into_transform_default_animation/A.kt
+++ b/SKIE/acceptance-tests/functional/src/test/resources/tests/coroutines/flow/swiftui/collect/animation/collect_into_transform_default_animation/A.kt
@@ -1,0 +1,6 @@
+package `tests`.`coroutines`.`flow`.`swiftui`.`collect`.`animation`.`collect_into_transform_default_animation`
+
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+
+val counter: StateFlow<Int> = MutableStateFlow(0)

--- a/SKIE/acceptance-tests/functional/src/test/resources/tests/coroutines/flow/swiftui/collect/animation/collect_into_transform_default_animation/_.swift
+++ b/SKIE/acceptance-tests/functional/src/test/resources/tests/coroutines/flow/swiftui/collect/animation/collect_into_transform_default_animation/_.swift
@@ -1,0 +1,15 @@
+import SwiftUI
+
+@available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *)
+struct TestView: View {
+    @State var value: Int = 0
+
+    var body: some View {
+        Text("")
+            .collect(flow: AKt.counter, into: $value, animation: .default) { item in
+                item.intValue
+            }
+    }
+}
+
+exit(0)

--- a/SKIE/acceptance-tests/functional/src/test/resources/tests/coroutines/flow/swiftui/observing/animation/default_animation/A.kt
+++ b/SKIE/acceptance-tests/functional/src/test/resources/tests/coroutines/flow/swiftui/observing/animation/default_animation/A.kt
@@ -1,0 +1,6 @@
+package `tests`.`coroutines`.`flow`.`swiftui`.`observing`.`animation`.`default_animation`
+
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+
+val counter: StateFlow<Int> = MutableStateFlow(0)

--- a/SKIE/acceptance-tests/functional/src/test/resources/tests/coroutines/flow/swiftui/observing/animation/default_animation/_.swift
+++ b/SKIE/acceptance-tests/functional/src/test/resources/tests/coroutines/flow/swiftui/observing/animation/default_animation/_.swift
@@ -1,7 +1,10 @@
 import SwiftUI
 
-let view = Observing(AKt.counter, animation: .default) { value in
-    Text("\(value)")
+if #available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *) {
+    let view = Observing(AKt.counter, animation: .default) { value in
+        Text("\(value)")
+    }
+    _ = view
 }
 
 exit(0)

--- a/SKIE/acceptance-tests/functional/src/test/resources/tests/coroutines/flow/swiftui/observing/animation/default_animation/_.swift
+++ b/SKIE/acceptance-tests/functional/src/test/resources/tests/coroutines/flow/swiftui/observing/animation/default_animation/_.swift
@@ -1,0 +1,7 @@
+import SwiftUI
+
+let view = Observing(AKt.counter, animation: .default) { value in
+    Text("\(value)")
+}
+
+exit(0)

--- a/SKIE/acceptance-tests/functional/src/test/resources/tests/coroutines/flow/swiftui/observing/animation/flow_initial_content/A.kt
+++ b/SKIE/acceptance-tests/functional/src/test/resources/tests/coroutines/flow/swiftui/observing/animation/flow_initial_content/A.kt
@@ -1,0 +1,6 @@
+package `tests`.`coroutines`.`flow`.`swiftui`.`observing`.`animation`.`flow_initial_content`
+
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flowOf
+
+fun items(): Flow<Int> = flowOf(1, 2, 3)

--- a/SKIE/acceptance-tests/functional/src/test/resources/tests/coroutines/flow/swiftui/observing/animation/flow_initial_content/_.swift
+++ b/SKIE/acceptance-tests/functional/src/test/resources/tests/coroutines/flow/swiftui/observing/animation/flow_initial_content/_.swift
@@ -1,9 +1,12 @@
 import SwiftUI
 
-let view = Observing(AKt.items(), animation: .default) {
-    ProgressView()
-} content: { item in
-    Text("\(item)")
+if #available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *) {
+    let view = Observing(AKt.items(), animation: .default) {
+        ProgressView()
+    } content: { item in
+        Text("\(item)")
+    }
+    _ = view
 }
 
 exit(0)

--- a/SKIE/acceptance-tests/functional/src/test/resources/tests/coroutines/flow/swiftui/observing/animation/flow_initial_content/_.swift
+++ b/SKIE/acceptance-tests/functional/src/test/resources/tests/coroutines/flow/swiftui/observing/animation/flow_initial_content/_.swift
@@ -1,0 +1,9 @@
+import SwiftUI
+
+let view = Observing(AKt.items(), animation: .default) {
+    ProgressView()
+} content: { item in
+    Text("\(item)")
+}
+
+exit(0)

--- a/SKIE/acceptance-tests/functional/src/test/resources/tests/coroutines/flow/swiftui/observing/animation/flow_with_initial_value/A.kt
+++ b/SKIE/acceptance-tests/functional/src/test/resources/tests/coroutines/flow/swiftui/observing/animation/flow_with_initial_value/A.kt
@@ -1,0 +1,6 @@
+package `tests`.`coroutines`.`flow`.`swiftui`.`observing`.`animation`.`flow_with_initial_value`
+
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flowOf
+
+fun ticking(): Flow<Int> = flowOf(1, 2, 3)

--- a/SKIE/acceptance-tests/functional/src/test/resources/tests/coroutines/flow/swiftui/observing/animation/flow_with_initial_value/_.swift
+++ b/SKIE/acceptance-tests/functional/src/test/resources/tests/coroutines/flow/swiftui/observing/animation/flow_with_initial_value/_.swift
@@ -1,0 +1,7 @@
+import SwiftUI
+
+let view = Observing(AKt.ticking().withInitialValue(KotlinInt(0)), animation: .default) { tick in
+    Text("\(tick)")
+}
+
+exit(0)

--- a/SKIE/acceptance-tests/functional/src/test/resources/tests/coroutines/flow/swiftui/observing/animation/flow_with_initial_value/_.swift
+++ b/SKIE/acceptance-tests/functional/src/test/resources/tests/coroutines/flow/swiftui/observing/animation/flow_with_initial_value/_.swift
@@ -1,7 +1,10 @@
 import SwiftUI
 
-let view = Observing(AKt.ticking().withInitialValue(KotlinInt(0)), animation: .default) { tick in
-    Text("\(tick)")
+if #available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *) {
+    let view = Observing(AKt.ticking().withInitialValue(KotlinInt(0)), animation: .default) { tick in
+        Text("\(tick)")
+    }
+    _ = view
 }
 
 exit(0)

--- a/SKIE/acceptance-tests/functional/src/test/resources/tests/coroutines/flow/swiftui/observing/animation/multiple_flows/A.kt
+++ b/SKIE/acceptance-tests/functional/src/test/resources/tests/coroutines/flow/swiftui/observing/animation/multiple_flows/A.kt
@@ -1,0 +1,7 @@
+package `tests`.`coroutines`.`flow`.`swiftui`.`observing`.`animation`.`multiple_flows`
+
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+
+val counter1: StateFlow<Int> = MutableStateFlow(0)
+val counter2: StateFlow<Int> = MutableStateFlow(0)

--- a/SKIE/acceptance-tests/functional/src/test/resources/tests/coroutines/flow/swiftui/observing/animation/multiple_flows/_.swift
+++ b/SKIE/acceptance-tests/functional/src/test/resources/tests/coroutines/flow/swiftui/observing/animation/multiple_flows/_.swift
@@ -1,0 +1,7 @@
+import SwiftUI
+
+let view = Observing(AKt.counter1, AKt.counter2, animation: .default) { v1, v2 in
+    Text("\(v1) \(v2)")
+}
+
+exit(0)

--- a/SKIE/acceptance-tests/functional/src/test/resources/tests/coroutines/flow/swiftui/observing/animation/multiple_flows/_.swift
+++ b/SKIE/acceptance-tests/functional/src/test/resources/tests/coroutines/flow/swiftui/observing/animation/multiple_flows/_.swift
@@ -1,7 +1,10 @@
 import SwiftUI
 
-let view = Observing(AKt.counter1, AKt.counter2, animation: .default) { v1, v2 in
-    Text("\(v1) \(v2)")
+if #available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *) {
+    let view = Observing(AKt.counter1, AKt.counter2, animation: .default) { v1, v2 in
+        Text("\(v1) \(v2)")
+    }
+    _ = view
 }
 
 exit(0)

--- a/SKIE/acceptance-tests/functional/src/test/resources/tests/coroutines/flow/swiftui/observing/animation/nil_animation/A.kt
+++ b/SKIE/acceptance-tests/functional/src/test/resources/tests/coroutines/flow/swiftui/observing/animation/nil_animation/A.kt
@@ -1,0 +1,6 @@
+package `tests`.`coroutines`.`flow`.`swiftui`.`observing`.`animation`.`nil_animation`
+
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+
+val counter: StateFlow<Int> = MutableStateFlow(0)

--- a/SKIE/acceptance-tests/functional/src/test/resources/tests/coroutines/flow/swiftui/observing/animation/nil_animation/_.swift
+++ b/SKIE/acceptance-tests/functional/src/test/resources/tests/coroutines/flow/swiftui/observing/animation/nil_animation/_.swift
@@ -1,7 +1,10 @@
 import SwiftUI
 
-let view = Observing(AKt.counter, animation: nil) { value in
-    Text("\(value)")
+if #available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *) {
+    let view = Observing(AKt.counter, animation: nil) { value in
+        Text("\(value)")
+    }
+    _ = view
 }
 
 exit(0)

--- a/SKIE/acceptance-tests/functional/src/test/resources/tests/coroutines/flow/swiftui/observing/animation/nil_animation/_.swift
+++ b/SKIE/acceptance-tests/functional/src/test/resources/tests/coroutines/flow/swiftui/observing/animation/nil_animation/_.swift
@@ -1,0 +1,7 @@
+import SwiftUI
+
+let view = Observing(AKt.counter, animation: nil) { value in
+    Text("\(value)")
+}
+
+exit(0)

--- a/SKIE/acceptance-tests/functional/src/test/resources/tests/coroutines/flow/swiftui/observing/animation/no_animation/A.kt
+++ b/SKIE/acceptance-tests/functional/src/test/resources/tests/coroutines/flow/swiftui/observing/animation/no_animation/A.kt
@@ -1,0 +1,6 @@
+package `tests`.`coroutines`.`flow`.`swiftui`.`observing`.`animation`.`no_animation`
+
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+
+val counter: StateFlow<Int> = MutableStateFlow(0)

--- a/SKIE/acceptance-tests/functional/src/test/resources/tests/coroutines/flow/swiftui/observing/animation/no_animation/_.swift
+++ b/SKIE/acceptance-tests/functional/src/test/resources/tests/coroutines/flow/swiftui/observing/animation/no_animation/_.swift
@@ -1,7 +1,10 @@
 import SwiftUI
 
-let view = Observing(AKt.counter) { value in
-    Text("\(value)")
+if #available(iOS 15.0, macOS 12.0, tvOS 15.0, watchOS 8.0, *) {
+    let view = Observing(AKt.counter) { value in
+        Text("\(value)")
+    }
+    _ = view
 }
 
 exit(0)

--- a/SKIE/acceptance-tests/functional/src/test/resources/tests/coroutines/flow/swiftui/observing/animation/no_animation/_.swift
+++ b/SKIE/acceptance-tests/functional/src/test/resources/tests/coroutines/flow/swiftui/observing/animation/no_animation/_.swift
@@ -1,0 +1,7 @@
+import SwiftUI
+
+let view = Observing(AKt.counter) { value in
+    Text("\(value)")
+}
+
+exit(0)

--- a/SKIE/kotlin-compiler/core/src/main/kotlin/co/touchlab/skie/phases/runtime/SwiftUIFlowObservingGenerator.kt
+++ b/SKIE/kotlin-compiler/core/src/main/kotlin/co/touchlab/skie/phases/runtime/SwiftUIFlowObservingGenerator.kt
@@ -496,6 +496,12 @@ object SwiftUIFlowObservingGenerator {
                     visibility = SirVisibility.Private,
                 )
 
+                SirProperty(
+                    identifier = "animation",
+                    type = sirBuiltins.SwiftUI.Animation.defaultType.toNullable(),
+                    visibility = SirVisibility.Private,
+                )
+
                 SirConstructor(
                     visibility = SirVisibility.Internal,
                 ).apply {
@@ -506,8 +512,14 @@ object SwiftUIFlowObservingGenerator {
                         ),
                     )
 
+                    SirValueParameter(
+                        name = "animation",
+                        type = sirBuiltins.SwiftUI.Animation.defaultType.toNullable(),
+                    )
+
                     bodyBuilder.add {
                         addStatement("self.flows = flows")
+                        addStatement("self.animation = animation")
                         addStatement("self._values = SwiftUI.Published(initialValue: Swift.Array(repeating: nil, count: flows.count))")
                     }
                 }
@@ -583,7 +595,15 @@ object SwiftUIFlowObservingGenerator {
                     )
 
                     bodyBuilder.add {
-                        addStatement("values[index] = newValue")
+                        addCode("""
+                            if let animation {
+                                SwiftUI.withAnimation(animation) {
+                                    values[index] = newValue
+                                }
+                            } else {
+                                values[index] = newValue
+                            }
+                        """.trimIndent())
                     }
                 }
             }
@@ -650,6 +670,11 @@ object SwiftUIFlowObservingGenerator {
                     )
 
                     SirValueParameter(
+                        name = "animation",
+                        type = sirBuiltins.SwiftUI.Animation.defaultType.toNullable(),
+                    )
+
+                    SirValueParameter(
                         name = "content",
                         type = contentFactoryType.copy(isEscaping = true),
                         attributes = listOf(
@@ -660,7 +685,7 @@ object SwiftUIFlowObservingGenerator {
                     bodyBuilder.add {
                         addStatement("self.content = content")
                         addStatement(
-                            "self._observer = SwiftUI.StateObject(wrappedValue: %T(flows: flows))",
+                            "self._observer = SwiftUI.StateObject(wrappedValue: %T(flows: flows, animation: animation))",
                             skieSwiftFlowObserver.defaultType.evaluate().swiftPoetTypeName,
                         )
                     }
@@ -803,6 +828,11 @@ object SwiftUIFlowObservingGenerator {
                     type = extractValuesType.copy(isEscaping = false),
                 )
 
+                SirProperty(
+                    identifier = "animation",
+                    type = sirBuiltins.SwiftUI.Animation.defaultType.toNullable(),
+                )
+
                 SirConstructor(
                     attributes = listOf("_spi(SKIE)")
                 ).apply {
@@ -838,6 +868,12 @@ object SwiftUIFlowObservingGenerator {
                     )
 
                     SirValueParameter(
+                        name = "animation",
+                        type = sirBuiltins.SwiftUI.Animation.defaultType.toNullable(),
+                        defaultValue = "nil",
+                    )
+
+                    SirValueParameter(
                         name = "extractValues",
                         type = extractValuesType,
                     )
@@ -848,6 +884,7 @@ object SwiftUIFlowObservingGenerator {
                             self.flowIds = flowIds
                             self.initialContent = initialContent
                             self.content = content
+                            self.animation = animation
                             self.extractValues = extractValues
                         """.trimIndent())
                     }
@@ -859,7 +896,7 @@ object SwiftUIFlowObservingGenerator {
                         SirGetter().apply {
                             bodyBuilder.add {
                                 addCode("""
-                                    ObserveSkieSwiftFlows(flows: flows) { rawValues in
+                                    ObserveSkieSwiftFlows(flows: flows, animation: animation) { rawValues in
                                         if let values = extractValues(rawValues) {
                                             content(values)
                                         } else {
@@ -938,6 +975,12 @@ object SwiftUIFlowObservingGenerator {
                         }
 
                         SirValueParameter(
+                            name = "animation",
+                            type = sirBuiltins.SwiftUI.Animation.defaultType.toNullable(),
+                            defaultValue = "nil",
+                        )
+
+                        SirValueParameter(
                             attributes = listOf("SwiftUI.ViewBuilder"),
                             name = "initialContent",
                             type = LambdaSirType(
@@ -967,7 +1010,8 @@ object SwiftUIFlowObservingGenerator {
                                 +"flows: [${flowValueParameters.joinToString { it.name }}],\n"
                                 +"flowIds: [${flowValueParameters.joinToString { "Swift.ObjectIdentifier(${it.name}.delegate)" }}],\n"
                                 +"initialContent: initialContent,\n"
-                                +"content: content\n"
+                                +"content: content,\n"
+                                +"animation: animation\n"
                             }
                             ") { values in" {
                                 flowValueParameters.forEachIndexed { index, parameter ->
@@ -1053,6 +1097,12 @@ object SwiftUIFlowObservingGenerator {
                         }
 
                         SirValueParameter(
+                            name = "animation",
+                            type = sirBuiltins.SwiftUI.Animation.defaultType.toNullable(),
+                            defaultValue = "nil",
+                        )
+
+                        SirValueParameter(
                             attributes = listOf("SwiftUI.ViewBuilder"),
                             name = "content",
                             type = LambdaSirType(
@@ -1072,7 +1122,8 @@ object SwiftUIFlowObservingGenerator {
                                 +"flows: [${flowValueParameters.joinToString { "${it.name}.flow" }}],\n"
                                 +"flowIds: [${flowValueParameters.joinToString { "Swift.ObjectIdentifier(${it.name}.flow.delegate)" }}],\n"
                                 +"initialContent: SwiftUI.EmptyView.init,\n"
-                                +"content: content\n"
+                                +"content: content,\n"
+                                +"animation: animation\n"
                             }
                             ") { values in" {
                                 flowValueParameters.forEachIndexed { index, parameter ->

--- a/SKIE/kotlin-compiler/core/src/main/kotlin/co/touchlab/skie/phases/runtime/SwiftUIFlowObservingGenerator.kt
+++ b/SKIE/kotlin-compiler/core/src/main/kotlin/co/touchlab/skie/phases/runtime/SwiftUIFlowObservingGenerator.kt
@@ -83,6 +83,7 @@ object SwiftUIFlowObservingGenerator {
                         |
                         |- parameter flow: A SKIE-bridged Flow you with to collect.
                         |- parameter binding: A binding to a property where each new value will be set to.
+                        |- parameter animation: An optional animation to use when updating the binding with a new value.
                     """.trimMargin()
 
                     val flowTypeParameter = SirTypeParameter(
@@ -107,9 +108,23 @@ object SwiftUIFlowObservingGenerator {
                         )
                     )
 
+                    SirValueParameter(
+                        name = "animation",
+                        type = sirBuiltins.SwiftUI.Animation.defaultType.toNullable(),
+                        defaultValue = "nil",
+                    )
+
                     bodyBuilder.add {
                         addCode("collect(flow: flow) { newValue in%>")
-                        addStatement("binding.wrappedValue = newValue")
+                        addCode("""
+                            if let animation {
+                                SwiftUI.withAnimation(animation) {
+                                    binding.wrappedValue = newValue
+                                }
+                            } else {
+                                binding.wrappedValue = newValue
+                            }
+                        """.trimIndent())
                         addCode("%<}")
                     }
                 }
@@ -143,6 +158,7 @@ object SwiftUIFlowObservingGenerator {
                         |
                         |- parameter flow: A SKIE-bridged Flow you with to collect.
                         |- parameter binding: A binding to a property where each new value will be set to.
+                        |- parameter animation: An optional animation to use when updating the binding with a new value.
                         |- parameter transform: An async closure to transform any value emitted by the flow into a one expected by the binding.
                         |                       Returning `nil` from this closure will reject the value.
                     """.trimMargin()
@@ -170,6 +186,12 @@ object SwiftUIFlowObservingGenerator {
                     )
 
                     SirValueParameter(
+                        name = "animation",
+                        type = sirBuiltins.SwiftUI.Animation.defaultType.toNullable(),
+                        defaultValue = "nil",
+                    )
+
+                    SirValueParameter(
                         name = "transform",
                         type = LambdaSirType(
                             valueParameterTypes = listOf(
@@ -186,7 +208,15 @@ object SwiftUIFlowObservingGenerator {
                     bodyBuilder.add {
                         addCode("collect(flow: flow) { newValue in%>")
                         beginControlFlow("if", "let newTransformedValue = await transform(newValue)")
-                        addStatement("binding.wrappedValue = newTransformedValue")
+                        addCode("""
+                            if let animation {
+                                SwiftUI.withAnimation(animation) {
+                                    binding.wrappedValue = newTransformedValue
+                                }
+                            } else {
+                                binding.wrappedValue = newTransformedValue
+                            }
+                        """.trimIndent())
                         endControlFlow("if")
                         addCode("%<}")
                     }

--- a/SKIE/kotlin-compiler/core/src/main/kotlin/co/touchlab/skie/sir/builtin/SirBuiltin.kt
+++ b/SKIE/kotlin-compiler/core/src/main/kotlin/co/touchlab/skie/sir/builtin/SirBuiltin.kt
@@ -199,6 +199,8 @@ class SirBuiltins(
                 // TODO: Declared as: `associatedtype ObjectWillChangePublisher : Publisher = ObservableObjectPublisher where Self.ObjectWillChangePublisher.Failure == Never`
                 SirTypeParameter("ObjectWillChangePublisher")
             }
+
+            val Animation by Struct()
         }
 
         class Skie(


### PR DESCRIPTION
- Adds an extra parameter to `Observing` and `collect(into:)` that enables animation during the state changes
- Behind the scenes, all it does is wrap the value change with a `withAnimation` using the given animation configuration