### PR TITLE
Allow Skie to run with Kotlin 2.4.10

### DIFF
--- a/common-gradle/gradle.properties
+++ b/common-gradle/gradle.properties
@@ -15,7 +15,7 @@ kotlin.suppressGradlePluginWarnings=IncorrectCompileOnlyDependencyWarning
 
 pluginId=co.touchlab.skie
 
-versionSupport.kotlin=2.0.0(2.0.10), 2.0.20(2.0.21), 2.1.0(2.1.10), 2.1.20(2.1.21), 2.2.0(2.2.10), 2.2.20(2.2.21), 2.3.0(2.3.10), 2.3.20(2.3.21), 2.4.0
+versionSupport.kotlin=2.0.0(2.0.10), 2.0.20(2.0.21), 2.1.0(2.1.10), 2.1.20(2.1.21), 2.2.0(2.2.10), 2.2.20(2.2.21), 2.3.0(2.3.10), 2.3.20(2.3.21), 2.4.0(2.4.10)
 versionSupport.kotlin.klibCompiler=2.0.21
 #versionSupport.kotlin.enabledVersions=2.0.0
 #versionSupport.kotlin.enabledVersions=2.0.20
@@ -27,6 +27,7 @@ versionSupport.kotlin.klibCompiler=2.0.21
 #versionSupport.kotlin.enabledVersions=2.3.20
 #versionSupport.kotlin.enabledVersions=2.3.21
 #versionSupport.kotlin.enabledVersions=2.4.0
+#versionSupport.kotlin.enabledVersions=2.4.10
 
 #skie.kgpVersion=2.2.0
 

--- a/dev-support/build.gradle.kts
+++ b/dev-support/build.gradle.kts
@@ -5,7 +5,8 @@ plugins {
 //     kotlin("multiplatform") version "2.2.21" apply false
 //     kotlin("multiplatform") version "2.3.0-RC" apply false
 //     kotlin("multiplatform") version "2.3.20" apply false
-    kotlin("multiplatform") version "2.4.0" apply false
+//     kotlin("multiplatform") version "2.4.0" apply false
+    kotlin("multiplatform") version "2.4.10" apply false
 }
 
 buildscript {


### PR DESCRIPTION
Current Skie version is already compatible with Kotlin 2.4.10.
Internally bumped and tested and it built and ran just fine, so just opening a PR to allow Skie to run with the new Kotlin version.

should close https://github.com/touchlab/SKIE/issues/200