### PR TITLE
Propagate Kotlin KDoc to generated Swift declarations

### DIFF
--- a/SKIE/kotlin-compiler/core/src/main/kotlin/co/touchlab/skie/kir/element/KirClass.kt
+++ b/SKIE/kotlin-compiler/core/src/main/kotlin/co/touchlab/skie/kir/element/KirClass.kt
@@ -24,6 +24,9 @@ class KirClass(
 
     lateinit var oirClass: OirClass
 
+    // SKIE#166: KDoc of the Kotlin declaration, propagated to the generated Swift.
+    var documentation: String? = null
+
     override val classes: MutableList<KirClass> = mutableListOf()
 
     val kotlinIdentifier: String by lazy {

--- a/SKIE/kotlin-compiler/core/src/main/kotlin/co/touchlab/skie/kir/element/KirProperty.kt
+++ b/SKIE/kotlin-compiler/core/src/main/kotlin/co/touchlab/skie/kir/element/KirProperty.kt
@@ -25,6 +25,9 @@ class KirProperty(
 
     lateinit var oirProperty: OirProperty
 
+    // SKIE#166: KDoc of the Kotlin declaration, propagated to the generated Swift.
+    var documentation: String? = null
+
     override val oirCallableDeclaration: OirCallableDeclaration
         get() = oirProperty
 

--- a/SKIE/kotlin-compiler/core/src/main/kotlin/co/touchlab/skie/kir/element/KirSimpleFunction.kt
+++ b/SKIE/kotlin-compiler/core/src/main/kotlin/co/touchlab/skie/kir/element/KirSimpleFunction.kt
@@ -28,6 +28,9 @@ class KirSimpleFunction(
 
     lateinit var oirSimpleFunction: OirSimpleFunction
 
+    // SKIE#166: KDoc of the Kotlin declaration, propagated to the generated Swift.
+    var documentation: String? = null
+
     override val oirCallableDeclaration: OirCallableDeclaration
         get() = oirSimpleFunction
 

--- a/SKIE/kotlin-compiler/core/src/main/kotlin/co/touchlab/skie/phases/features/functions/GlobalMembersConvertorDelegate.kt
+++ b/SKIE/kotlin-compiler/core/src/main/kotlin/co/touchlab/skie/phases/features/functions/GlobalMembersConvertorDelegate.kt
@@ -40,6 +40,10 @@ class GlobalMembersConvertorDelegate(
                 addFunctionBody(sirFunction)
 
                 configureBridge(function, sirFunction, this)
+
+                // SKIE#166: the file-scope wrapper is what Swift users call, so it
+                // must carry the Kotlin KDoc (shallowCopy does not preserve it).
+                function.documentation?.let { documentation = it }
             }
         }
 
@@ -77,6 +81,10 @@ class GlobalMembersConvertorDelegate(
                 sirProperty.setter?.let {
                     addPropertySetter(it, sirProperty)
                 }
+
+                // SKIE#166: the file-scope wrapper is what Swift users see, so it
+                // must carry the Kotlin KDoc (shallowCopy does not preserve it).
+                property.documentation?.let { documentation = it }
 
                 property.bridgedSirProperty = this
             }

--- a/SKIE/kotlin-compiler/core/src/main/kotlin/co/touchlab/skie/phases/sir/member/CreateSirMembersPhase.kt
+++ b/SKIE/kotlin-compiler/core/src/main/kotlin/co/touchlab/skie/phases/sir/member/CreateSirMembersPhase.kt
@@ -84,6 +84,7 @@ class CreateSirMembersPhase(
             isHidden = function.isHidden,
         ).apply {
             createValueParameters(function, swiftFunctionName)
+            function.documentation?.let { documentation = it }
         }
 
         function.oirSimpleFunction.originalSirFunction = sirFunction
@@ -114,6 +115,8 @@ class CreateSirMembersPhase(
                     throws = false,
                 )
             }
+
+            property.documentation?.let { documentation = it }
         }
 
         oirProperty.originalSirProperty = sirProperty

--- a/SKIE/kotlin-compiler/core/src/main/kotlin/co/touchlab/skie/phases/sir/type/CreateKotlinSirTypesPhase.kt
+++ b/SKIE/kotlin-compiler/core/src/main/kotlin/co/touchlab/skie/phases/sir/type/CreateKotlinSirTypesPhase.kt
@@ -43,6 +43,8 @@ class CreateKotlinSirTypesPhase : SirPhase {
             isHidden = kirClass.configuration[SkieVisibility] in listOf(SkieVisibility.Level.PublicButHidden, SkieVisibility.Level.PublicButReplaced),
         )
 
+        kirClass.documentation?.let { sirClass.documentation = it }
+
         createTypeParameters(kirClass.oirClass, sirClass)
 
         kirClass.oirClass.originalSirClass = sirClass

--- a/SKIE/kotlin-compiler/linker-plugin/src/main/kotlin/co/touchlab/skie/kir/util/DescriptorKDoc.kt
+++ b/SKIE/kotlin-compiler/linker-plugin/src/main/kotlin/co/touchlab/skie/kir/util/DescriptorKDoc.kt
@@ -1,0 +1,42 @@
+@file:Suppress("invisible_reference", "invisible_member")
+
+package co.touchlab.skie.kir.util
+
+import org.jetbrains.kotlin.backend.common.serialization.extractSerializedKdocString
+import org.jetbrains.kotlin.descriptors.DeclarationDescriptor
+
+/**
+ * Extracts the KDoc of a Kotlin declaration and returns it as plain documentation
+ * content (no `/** */` delimiters, no leading `*`), suitable for handing to the
+ * Swift code generator which re-wraps it into a Swift doc comment.
+ *
+ * At framework-linking time declarations are deserialized from klibs, so the KDoc
+ * is read from the serialized klib metadata — the same source the Obj-C header uses.
+ *
+ * Fixes touchlab/SKIE#166.
+ */
+internal fun DeclarationDescriptor.extractDocumentationOrNull(): String? {
+    val rawKDoc = extractSerializedKdocString() ?: return null
+
+    return rawKDoc.cleanKDocContent().takeIf { it.isNotBlank() }
+}
+
+private fun String.cleanKDocContent(): String {
+    var text = trim()
+
+    if (text.startsWith("/**")) {
+        text = text.removePrefix("/**")
+    }
+    if (text.endsWith("*/")) {
+        text = text.removeSuffix("*/")
+    }
+
+    return text
+        .lines()
+        .joinToString("\n") { line ->
+            // Drop the leading ` * ` (or `*`) margin that KDoc lines conventionally carry.
+            line.trimStart().removePrefix("*").let { if (it.startsWith(" ")) it.drop(1) else it }
+        }
+        .trim('\n')
+        .trimEnd()
+}

--- a/SKIE/kotlin-compiler/linker-plugin/src/main/kotlin/co/touchlab/skie/phases/kir/CreateExposedKirTypesPhase.kt
+++ b/SKIE/kotlin-compiler/linker-plugin/src/main/kotlin/co/touchlab/skie/phases/kir/CreateExposedKirTypesPhase.kt
@@ -12,6 +12,7 @@ import co.touchlab.skie.kir.element.KirTypeParameter
 import co.touchlab.skie.kir.element.superClass
 import co.touchlab.skie.kir.type.DeclarationBackedKirType
 import co.touchlab.skie.kir.type.translation.withTypeParameterScope
+import co.touchlab.skie.kir.util.extractDocumentationOrNull
 import co.touchlab.skie.kir.util.hasArgumentValue
 import co.touchlab.skie.oir.element.OirTypeParameter
 import co.touchlab.skie.phases.KirPhase
@@ -105,6 +106,9 @@ class CreateExposedKirTypesPhase(
             nestingLevel = getNestingLevel(descriptor),
             configuration = descriptorConfigurationProvider.getConfiguration(descriptor),
         )
+
+        // SKIE#166: carry the Kotlin KDoc onto the generated Swift declaration.
+        kirClass.documentation = descriptor.extractDocumentationOrNull()
 
         descriptorKirProvider.registerClass(kirClass, descriptor)
 

--- a/SKIE/kotlin-compiler/linker-plugin/src/main/kotlin/co/touchlab/skie/phases/kir/CreateKirPropertiesPhase.kt
+++ b/SKIE/kotlin-compiler/linker-plugin/src/main/kotlin/co/touchlab/skie/phases/kir/CreateKirPropertiesPhase.kt
@@ -7,6 +7,7 @@ import co.touchlab.skie.kir.element.KirClass
 import co.touchlab.skie.kir.element.KirProperty
 import co.touchlab.skie.kir.type.translation.withTypeParameterScope
 import co.touchlab.skie.kir.util.addOverrides
+import co.touchlab.skie.kir.util.extractDocumentationOrNull
 import co.touchlab.skie.phases.KirPhase
 import org.jetbrains.kotlin.descriptors.PropertyDescriptor
 
@@ -62,6 +63,9 @@ internal class CreateKirPropertiesPhase(
                 configuration = descriptorConfigurationProvider.getConfiguration(originalDescriptor),
                 modality = descriptor.kirModality,
             )
+
+            // SKIE#166: carry the Kotlin KDoc onto the generated Swift declaration.
+            property.documentation = originalDescriptor.extractDocumentationOrNull()
 
             descriptorKirProvider.registerCallableDeclaration(property, descriptor)
 

--- a/SKIE/kotlin-compiler/linker-plugin/src/main/kotlin/co/touchlab/skie/phases/kir/CreateKirSimpleFunctionsPhase.kt
+++ b/SKIE/kotlin-compiler/linker-plugin/src/main/kotlin/co/touchlab/skie/phases/kir/CreateKirSimpleFunctionsPhase.kt
@@ -8,6 +8,7 @@ import co.touchlab.skie.kir.element.KirClass
 import co.touchlab.skie.kir.element.KirSimpleFunction
 import co.touchlab.skie.kir.type.translation.withTypeParameterScope
 import co.touchlab.skie.kir.util.addOverrides
+import co.touchlab.skie.kir.util.extractDocumentationOrNull
 import co.touchlab.skie.phases.KirPhase
 import org.jetbrains.kotlin.descriptors.FunctionDescriptor
 import org.jetbrains.kotlin.descriptors.PropertyAccessorDescriptor
@@ -92,6 +93,9 @@ internal class CreateKirSimpleFunctionsPhase(
                 configuration = getFunctionConfiguration(descriptor),
                 modality = descriptor.kirModality,
             )
+
+            // SKIE#166: carry the Kotlin KDoc onto the generated Swift declaration.
+            function.documentation = originalDescriptor.extractDocumentationOrNull()
 
             descriptorKirProvider.registerCallableDeclaration(function, descriptor)
 


### PR DESCRIPTION
# Propagate Kotlin KDoc to generated Swift declarations

Fixes #166.

## Problem

SKIE-generated Swift wrappers (top-level functions, suspend functions, and
properties) carried **no documentation**, even though the Kotlin KDoc was
present in the generated Objective-C header. In Xcode/Swift the documentation
was therefore lost — quick-help showed nothing for SKIE-wrapped declarations.

Before (generated Swift):

```swift
public func greetSuspend(name: Swift.String, completionHandler: ...) -> Swift.Void {
    return Shared.GreeterKt.greetSuspend(name: name, completionHandler: completionHandler)
}
```

## Root cause

The Swift IR (`SirDeclaration`) already has a `documentation` field, and the
Swift code generator already emits it (`SirCodeGenerator.addDoc`). But nothing
ever populated it from the Kotlin declaration — the only assignments in the tree
were hardcoded strings for SKIE's own SwiftUI runtime types — so for every user
declaration it stayed `""`.

## Fix

At framework-link time declarations are deserialized from klibs, so the KDoc is
read from the serialized klib metadata via `extractSerializedKdocString` — the
same source the Obj-C header uses. The change:

1. adds a `documentation` field to `KirSimpleFunction`, `KirProperty`, and
   `KirClass`;
2. populates it from the KDoc in the `CreateKir*` phases, via a small helper
   (`DescriptorKDoc.extractDocumentationOrNull`) that strips the `/** */` and
   `*` margins so the generator re-wraps clean content;
3. copies it onto the SIR declarations in the create-SIR phases and in the
   file-scope wrapper generators (`shallowCopy` does not preserve it).

The Swift code generator already renders `documentation`, so no writer change is
needed.

After (generated Swift):

```swift
/**
 Returns a friendly greeting for [name].

 This suspend function uses SKIE's suspend interop (enabled by default).
 */
public func greetSuspend(name: Swift.String, completionHandler: ...) -> Swift.Void {
    return Shared.GreeterKt.greetSuspend(name: name, completionHandler: completionHandler)
}
```

## Testing

- Built a minimal KMP framework with documented top-level functions (plain and
  `suspend`) and a documented top-level property; verified each generated Swift
  wrapper now carries its KDoc as a Swift doc comment, correctly formatted (no
  nested `/** */`).
- Ran the `:acceptance-tests:functional` suite on the Kotlin 2.3.20 variant.
  The change is output-neutral for existing tests: none of the acceptance-test
  inputs contain KDoc, so their generated Swift is byte-identical to before.

## Notes

- Member functions/properties of plain (non file-scope) classes and plain
  classes themselves are exposed through the Obj-C header rather than a
  SKIE-generated Swift file, so their KDoc already reaches Xcode via the header;
  the SIR `documentation` added for those declarations activates when SKIE does
  emit Swift for a type (e.g. sealed/enum interop).
